### PR TITLE
Evite l'aliasing de la Lobster sous Chrome (Windows)

### DIFF
--- a/css/parisjs.css
+++ b/css/parisjs.css
@@ -1,6 +1,6 @@
 *{margin: 0; padding: 0; font-family:inherit;}
 
-h1, h2, h3 { font-family: 'Lobster', arial, serif; color: #4F4005; margin-top: 0.2em; color:#111}
+h1, h2, h3 { font-family: 'Lobster', arial, serif; color: #4F4005; margin-top: 0.2em; color:#111; text-shadow: 1px 1px 1px #DE973B;}
 h1 { text-align: center;}
 h2 { font-size: 2em;}
 


### PR DESCRIPTION
Pas expert des font, mais j'ai remarqué que cela répare les font avec aliasing sous Chrome-Windows, en particulier la Lobster
