### PR TITLE
Keep translations separate from nav links on mobile

### DIFF
--- a/styles/header.css
+++ b/styles/header.css
@@ -56,6 +56,7 @@
   }
   .header__nav {
     display: block;
+    padding-bottom: 10px;
   }
   .header__nav a {
     display: block;


### PR DESCRIPTION
- I wanted to add this PR, because there isn't any space between nav links and translations. IMO they should be kept separately and it looks better (imo as well 😃)