### PR TITLE
Fix twitter avatars

### DIFF
--- a/content/meetups/2010-10-12.md
+++ b/content/meetups/2010-10-12.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jedisct1'
         url: 'http://twitter.com/jedisct1'
-        avatar: https://avatars.io/twitter/jedisct1
+        avatar: https://api.microlink.io/?url=https://twitter.com/jedisct1&embed=image.url
     slides:
       - >-
         http://www.slideshare.net/jedisct1/abusing-javascript-to-speedup-mobile-web-sites
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: '@gcachet'
         url: 'https://github.com/gcachet'
-        avatar: 'https://avatars.io/twitter/gcachet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gcachet&embed=image.url'
     slides:
       - >-
         https://docs.google.com/present/view?id=0AVEtwWraWZ-3ZGcydnMyYjhfNTE2Y3o4cmJjZnE
@@ -35,7 +35,7 @@ talks:
     authors:
       - name: '@paulgreg'
         url: 'http://twitter.com/paulgreg'
-        avatar: 'https://avatars.io/twitter/paulgreg'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/paulgreg&embed=image.url'
     slides:
       - 'http://javascript.training.free.fr/couchdb/intro/intro-couchdb.html'
     links: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: '@no_way'
         url: 'http://twitter.com/no_way'
-        avatar: https://avatars.io/twitter/no_way
+        avatar: https://api.microlink.io/?url=https://twitter.com/no_way&embed=image.url
     slides:
       - >-
         https://docs.google.com/document/pub?id=1ugTkpww_UWZbjFjJ7QjVP6KBG-5-4zzjfJ_VE1XEkgw
@@ -58,7 +58,7 @@ talks:
     authors:
       - name: '@42loops'
         url: 'http://twitter.com/42loops'
-        avatar: 'https://avatars.io/twitter/42loops'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&embed=image.url'
     slides:
       - 'http://42loops.com/playing-with-webkit/#1'
     links: []
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'http://github.com/francois2metz'
-        avatar: 'https://avatars.io/twitter/francois2metz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
     slides:
       - 'http://tests-parisjs.herokuapp.com/#1'
     links: []

--- a/content/meetups/2010-10-12.md
+++ b/content/meetups/2010-10-12.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jedisct1'
         url: 'http://twitter.com/jedisct1'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jedisct1&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jedisct1&amps;embed=image.url
     slides:
       - >-
         http://www.slideshare.net/jedisct1/abusing-javascript-to-speedup-mobile-web-sites
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: '@gcachet'
         url: 'https://github.com/gcachet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/gcachet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gcachet&amps;embed=image.url'
     slides:
       - >-
         https://docs.google.com/present/view?id=0AVEtwWraWZ-3ZGcydnMyYjhfNTE2Y3o4cmJjZnE
@@ -35,7 +35,7 @@ talks:
     authors:
       - name: '@paulgreg'
         url: 'http://twitter.com/paulgreg'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/paulgreg&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/paulgreg&amps;embed=image.url'
     slides:
       - 'http://javascript.training.free.fr/couchdb/intro/intro-couchdb.html'
     links: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: '@no_way'
         url: 'http://twitter.com/no_way'
-        avatar: https://api.microlink.io/?url=https://twitter.com/no_way&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/no_way&amps;embed=image.url
     slides:
       - >-
         https://docs.google.com/document/pub?id=1ugTkpww_UWZbjFjJ7QjVP6KBG-5-4zzjfJ_VE1XEkgw
@@ -58,7 +58,7 @@ talks:
     authors:
       - name: '@42loops'
         url: 'http://twitter.com/42loops'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&amps;embed=image.url'
     slides:
       - 'http://42loops.com/playing-with-webkit/#1'
     links: []
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'http://github.com/francois2metz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&amps;embed=image.url'
     slides:
       - 'http://tests-parisjs.herokuapp.com/#1'
     links: []

--- a/content/meetups/2010-11-24.md
+++ b/content/meetups/2010-11-24.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@hexapode'
         url: 'http://twitter.com/hexapode'
-        avatar: https://avatars.io/twitter/hexapode
+        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&embed=image.url
     slides:
       - 'http://html5gamejam.org/slides/#slide1'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@mrspeaker'
         url: 'https://twitter.com/mrspeaker'
-        avatar: https://avatars.io/twitter/mrspeaker
+        avatar: https://api.microlink.io/?url=https://twitter.com/mrspeaker&embed=image.url
     slides:
       - null
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'https://github.com/francois2metz'
-        avatar: 'https://avatars.io/twitter/francois2metz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
     slides:
       - 'http://node-spore.herokuapp.com/#1'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://avatars.io/twitter/sylvinus
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
     slides:
       - 'http://www.slideshare.net/sylvinus/web-crawling-with-nodejs'
     links: []
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: '@challet'
         url: 'http://twitter.com/challet'
-        avatar: https://avatars.io/twitter/challet
+        avatar: https://api.microlink.io/?url=https://twitter.com/challet&embed=image.url
     slides:
       - 'http://talks.challet.eu/html5_video_mooplay/'
     links: []

--- a/content/meetups/2010-11-24.md
+++ b/content/meetups/2010-11-24.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@hexapode'
         url: 'http://twitter.com/hexapode'
-        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&amps;embed=image.url
     slides:
       - 'http://html5gamejam.org/slides/#slide1'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@mrspeaker'
         url: 'https://twitter.com/mrspeaker'
-        avatar: https://api.microlink.io/?url=https://twitter.com/mrspeaker&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/mrspeaker&amps;embed=image.url
     slides:
       - null
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'https://github.com/francois2metz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&amps;embed=image.url'
     slides:
       - 'http://node-spore.herokuapp.com/#1'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/sylvinus/web-crawling-with-nodejs'
     links: []
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: '@challet'
         url: 'http://twitter.com/challet'
-        avatar: https://api.microlink.io/?url=https://twitter.com/challet&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/challet&amps;embed=image.url
     slides:
       - 'http://talks.challet.eu/html5_video_mooplay/'
     links: []

--- a/content/meetups/2011-01-26.md
+++ b/content/meetups/2011-01-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@tonyskn'
         url: 'http://twitter.com/tonyskn'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tonyskn&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tonyskn&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/tonyskn/backbonejs-6728018'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&amps;embed=image.url
     slides:
       - >-
         http://www.slideshare.net/sylvinus/kinect-javascript-tech-talk-at-parisjs-jan-2011
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: '@meuble'
         url: 'http://twitter.com/meuble'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/meuble&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/meuble&amps;embed=image.url'
     slides:
       - 'http://raphael.imeuble.info/'
     links: []

--- a/content/meetups/2011-01-26.md
+++ b/content/meetups/2011-01-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@tonyskn'
         url: 'http://twitter.com/tonyskn'
-        avatar: 'https://avatars.io/twitter/tonyskn'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tonyskn&embed=image.url'
     slides:
       - 'http://www.slideshare.net/tonyskn/backbonejs-6728018'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://avatars.io/twitter/sylvinus
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
     slides:
       - >-
         http://www.slideshare.net/sylvinus/kinect-javascript-tech-talk-at-parisjs-jan-2011
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: '@meuble'
         url: 'http://twitter.com/meuble'
-        avatar: 'https://avatars.io/twitter/meuble'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/meuble&embed=image.url'
     slides:
       - 'http://raphael.imeuble.info/'
     links: []

--- a/content/meetups/2011-02-23.md
+++ b/content/meetups/2011-02-23.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@skaalf'
         url: 'http://twitter.com/skaalf'
-        avatar: https://api.microlink.io/?url=https://twitter.com/skaalf&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/skaalf&amps;embed=image.url
     slides:
       - 'http://jto.github.com/jseam/slides/#1'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@neyric'
         url: 'http://twitter.com/neyric'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/neyric&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/neyric&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/neyric/webhookit-parisjs-4'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - 'https://docs.google.com/present/view?id=dhng4bgf_50w9hhpkfx'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/sylvinus/node-quick-presentation-at-parisjs-4'
     links: []

--- a/content/meetups/2011-02-23.md
+++ b/content/meetups/2011-02-23.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@skaalf'
         url: 'http://twitter.com/skaalf'
-        avatar: https://avatars.io/twitter/skaalf
+        avatar: https://api.microlink.io/?url=https://twitter.com/skaalf&embed=image.url
     slides:
       - 'http://jto.github.com/jseam/slides/#1'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@neyric'
         url: 'http://twitter.com/neyric'
-        avatar: 'https://avatars.io/twitter/neyric'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/neyric&embed=image.url'
     slides:
       - 'http://www.slideshare.net/neyric/webhookit-parisjs-4'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - 'https://docs.google.com/present/view?id=dhng4bgf_50w9hhpkfx'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://avatars.io/twitter/sylvinus
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
     slides:
       - 'http://www.slideshare.net/sylvinus/node-quick-presentation-at-parisjs-4'
     links: []

--- a/content/meetups/2011-03-30.md
+++ b/content/meetups/2011-03-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - 'https://github.com/jeromeetienne/arenajs'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@hexapode'
         url: 'http://twitter.com/hexapode'
-        avatar: https://avatars.io/twitter/hexapode
+        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&embed=image.url
     slides:
       - 'http://pxdraw.com/HTML5DragAndDropSucks.com/#slide1'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@jie'
         url: 'http://twitter.com/jie'
-        avatar: https://avatars.io/twitter/jie
+        avatar: https://api.microlink.io/?url=https://twitter.com/jie&embed=image.url
     slides:
       - 'http://myjs.fr/'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@freakdev'
         url: 'http://twitter.com/freakdev'
-        avatar: https://avatars.io/twitter/freakdev
+        avatar: https://api.microlink.io/?url=https://twitter.com/freakdev&embed=image.url
     slides:
       - 'http://www.centurion-project.org/static/parisjs/index-en.html'
     links: []

--- a/content/meetups/2011-03-30.md
+++ b/content/meetups/2011-03-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - 'https://github.com/jeromeetienne/arenajs'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@hexapode'
         url: 'http://twitter.com/hexapode'
-        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&amps;embed=image.url
     slides:
       - 'http://pxdraw.com/HTML5DragAndDropSucks.com/#slide1'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@jie'
         url: 'http://twitter.com/jie'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jie&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jie&amps;embed=image.url
     slides:
       - 'http://myjs.fr/'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@freakdev'
         url: 'http://twitter.com/freakdev'
-        avatar: https://api.microlink.io/?url=https://twitter.com/freakdev&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/freakdev&amps;embed=image.url
     slides:
       - 'http://www.centurion-project.org/static/parisjs/index-en.html'
     links: []

--- a/content/meetups/2011-04-27.md
+++ b/content/meetups/2011-04-27.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - >-
         https://docs.google.com/present/view?id=0AT-TyRjy_tjnZGhuZzRiZ2ZfNjNna3Mzc2tjZg
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: '@trigrou'
         url: 'http://twitter.com/trigrou'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&amps;embed=image.url'
     slides:
       - 'http://plopbyte.net/insideglobetweeter/#1'
     links: []
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: '@eric_brechemier'
         url: 'http://twitter.com/eric_brechemier'
-        avatar: https://api.microlink.io/?url=https://twitter.com/eric_brechemier&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/eric_brechemier&amps;embed=image.url
     slides:
       - 'https://github.com/eric-brechemier/introduction_to_lb_js_scalableApp'
     links: []
@@ -47,7 +47,7 @@ talks:
     authors:
       - name: '@d_thevenin'
         url: 'http://twitter.com/d_thevenin'
-        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&amps;embed=image.url
     slides:
       - 'http://vinisketch.fr/downloads/prez/VAD_ParisJS6_en.pdf'
     links: []

--- a/content/meetups/2011-04-27.md
+++ b/content/meetups/2011-04-27.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - >-
         https://docs.google.com/present/view?id=0AT-TyRjy_tjnZGhuZzRiZ2ZfNjNna3Mzc2tjZg
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: '@trigrou'
         url: 'http://twitter.com/trigrou'
-        avatar: 'https://avatars.io/twitter/trigrou'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&embed=image.url'
     slides:
       - 'http://plopbyte.net/insideglobetweeter/#1'
     links: []
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: '@eric_brechemier'
         url: 'http://twitter.com/eric_brechemier'
-        avatar: https://avatars.io/twitter/eric_brechemier
+        avatar: https://api.microlink.io/?url=https://twitter.com/eric_brechemier&embed=image.url
     slides:
       - 'https://github.com/eric-brechemier/introduction_to_lb_js_scalableApp'
     links: []
@@ -47,7 +47,7 @@ talks:
     authors:
       - name: '@d_thevenin'
         url: 'http://twitter.com/d_thevenin'
-        avatar: https://avatars.io/twitter/d_thevenin
+        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&embed=image.url
     slides:
       - 'http://vinisketch.fr/downloads/prez/VAD_ParisJS6_en.pdf'
     links: []

--- a/content/meetups/2011-05-25.md
+++ b/content/meetups/2011-05-25.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@challet'
         url: 'http://twitter.com/challet'
-        avatar: https://api.microlink.io/?url=https://twitter.com/challet&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/challet&amps;embed=image.url
     slides:
       - null
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'https://github.com/francois2metz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&amps;embed=image.url'
     slides:
       - 'http://parisjs-expressiveness.herokuapp.com/#1'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - 'http://notes.jetienne.com/2011/05/26/Parisjs-7-slides.html'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@tbassetto'
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/tbassetto/fr-capture-vido-avec-html5'
     links: []
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: '@theystolemynick'
         url: 'http://twitter.com/theystolemynick'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/theystolemynick&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/theystolemynick&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/jpvincent/tls-connectes-et-dveloppement-web'
     links: []

--- a/content/meetups/2011-05-25.md
+++ b/content/meetups/2011-05-25.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@challet'
         url: 'http://twitter.com/challet'
-        avatar: https://avatars.io/twitter/challet
+        avatar: https://api.microlink.io/?url=https://twitter.com/challet&embed=image.url
     slides:
       - null
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'https://github.com/francois2metz'
-        avatar: 'https://avatars.io/twitter/francois2metz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
     slides:
       - 'http://parisjs-expressiveness.herokuapp.com/#1'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - 'http://notes.jetienne.com/2011/05/26/Parisjs-7-slides.html'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@tbassetto'
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://avatars.io/twitter/tbassetto'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
     slides:
       - 'http://www.slideshare.net/tbassetto/fr-capture-vido-avec-html5'
     links: []
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: '@theystolemynick'
         url: 'http://twitter.com/theystolemynick'
-        avatar: 'https://avatars.io/twitter/theystolemynick'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/theystolemynick&embed=image.url'
     slides:
       - 'http://www.slideshare.net/jpvincent/tls-connectes-et-dveloppement-web'
     links: []

--- a/content/meetups/2011-06-29.md
+++ b/content/meetups/2011-06-29.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jie'
         url: 'http://twitter.com/jie'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jie&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jie&amps;embed=image.url
     slides:
       - 'http://whyd.com/tmp/lambda.zip'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@hexapode'
         url: 'http://twitter.com/hexapode'
-        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&amps;embed=image.url
     slides:
       - null
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@adrienjoly'
         url: 'http://twitter.com/adrienjoly'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&amps;embed=image.url'
     slides:
       - 'http://blog.adrienjoly.com/introduction-to-asynchronous-db-access-using'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&amps;embed=image.url'
     slides:
       - 'http://www.b2bweb.fr/molokoloco/javascript-from-1998-to-2011/'
     links: []
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&amps;embed=image.url
     slides:
       - 'http://framework.joshfire.com/'
     links: []
@@ -66,7 +66,7 @@ talks:
     authors:
       - name: '@shinuza'
         url: 'http://twitter.com/shinuza'
-        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&amps;embed=image.url
     slides:
       - null
     links: []
@@ -77,7 +77,7 @@ talks:
     authors:
       - name: '@tbassetto'
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&amps;embed=image.url'
     slides:
       - null
     links: []
@@ -88,7 +88,7 @@ talks:
     authors:
       - name: '@revolunet'
         url: 'http://twitter.com/revolunet'
-        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&amps;embed=image.url
     slides:
       - 'http://www.revolunet.com/static/parisjs8/'
     links: []
@@ -99,10 +99,10 @@ talks:
     authors:
       - name: '@amorgaut'
         url: 'http://twitter.com/amorgaut'
-        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&amps;embed=image.url
       - name: '@thibarg'
         url: 'http://twitter.com/thibarg'
-        avatar: https://api.microlink.io/?url=https://twitter.com/thibarg&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/thibarg&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/alexandre_morgaut/paris-js-meetup-8-june-2011'
     links: []

--- a/content/meetups/2011-06-29.md
+++ b/content/meetups/2011-06-29.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jie'
         url: 'http://twitter.com/jie'
-        avatar: https://avatars.io/twitter/jie
+        avatar: https://api.microlink.io/?url=https://twitter.com/jie&embed=image.url
     slides:
       - 'http://whyd.com/tmp/lambda.zip'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@hexapode'
         url: 'http://twitter.com/hexapode'
-        avatar: https://avatars.io/twitter/hexapode
+        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&embed=image.url
     slides:
       - null
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@adrienjoly'
         url: 'http://twitter.com/adrienjoly'
-        avatar: 'https://avatars.io/twitter/adrienjoly'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&embed=image.url'
     slides:
       - 'http://blog.adrienjoly.com/introduction-to-asynchronous-db-access-using'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: 'https://avatars.io/twitter/molokoloco'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url'
     slides:
       - 'http://www.b2bweb.fr/molokoloco/javascript-from-1998-to-2011/'
     links: []
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://avatars.io/twitter/sylvinus
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
     slides:
       - 'http://framework.joshfire.com/'
     links: []
@@ -66,7 +66,7 @@ talks:
     authors:
       - name: '@shinuza'
         url: 'http://twitter.com/shinuza'
-        avatar: https://avatars.io/twitter/shinuza
+        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&embed=image.url
     slides:
       - null
     links: []
@@ -77,7 +77,7 @@ talks:
     authors:
       - name: '@tbassetto'
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://avatars.io/twitter/tbassetto'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
     slides:
       - null
     links: []
@@ -88,7 +88,7 @@ talks:
     authors:
       - name: '@revolunet'
         url: 'http://twitter.com/revolunet'
-        avatar: https://avatars.io/twitter/revolunet
+        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&embed=image.url
     slides:
       - 'http://www.revolunet.com/static/parisjs8/'
     links: []
@@ -99,10 +99,10 @@ talks:
     authors:
       - name: '@amorgaut'
         url: 'http://twitter.com/amorgaut'
-        avatar: https://avatars.io/twitter/amorgaut
+        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&embed=image.url
       - name: '@thibarg'
         url: 'http://twitter.com/thibarg'
-        avatar: https://avatars.io/twitter/thibarg
+        avatar: https://api.microlink.io/?url=https://twitter.com/thibarg&embed=image.url
     slides:
       - 'http://www.slideshare.net/alexandre_morgaut/paris-js-meetup-8-june-2011'
     links: []

--- a/content/meetups/2011-07-27.md
+++ b/content/meetups/2011-07-27.md
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@d_thevenin'
         url: 'http://twitter.com/d_thevenin'
-        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&amps;embed=image.url
     slides:
       - 'http://www.vinisketch.fr/downloads/prez/ParisJS9/PJS9_PGP_dthevenin.pdf'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@tbassetto'
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/tbassetto/prsentation-de-phonegap'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@42loops'
         url: 'http://twitter.com/42loops'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&amps;embed=image.url'
     slides:
       - 'http://42loops.com/phonegap/static/index.html'
     links: []
@@ -58,7 +58,7 @@ talks:
     authors:
       - name: '@ericplaquevent'
         url: 'http://twitter.com/ericplaquevent'
-        avatar: https://api.microlink.io/?url=https://twitter.com/ericplaquevent&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/ericplaquevent&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/erpla/parisjs-9-phonegap-feedbacks'
     links: []
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - 'https://docs.google.com/present/view?id=dhng4bgf_71c9txhrdb'
     links: []

--- a/content/meetups/2011-07-27.md
+++ b/content/meetups/2011-07-27.md
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@d_thevenin'
         url: 'http://twitter.com/d_thevenin'
-        avatar: https://avatars.io/twitter/d_thevenin
+        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&embed=image.url
     slides:
       - 'http://www.vinisketch.fr/downloads/prez/ParisJS9/PJS9_PGP_dthevenin.pdf'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@tbassetto'
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://avatars.io/twitter/tbassetto'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
     slides:
       - 'http://www.slideshare.net/tbassetto/prsentation-de-phonegap'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@42loops'
         url: 'http://twitter.com/42loops'
-        avatar: 'https://avatars.io/twitter/42loops'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&embed=image.url'
     slides:
       - 'http://42loops.com/phonegap/static/index.html'
     links: []
@@ -58,7 +58,7 @@ talks:
     authors:
       - name: '@ericplaquevent'
         url: 'http://twitter.com/ericplaquevent'
-        avatar: https://avatars.io/twitter/ericplaquevent
+        avatar: https://api.microlink.io/?url=https://twitter.com/ericplaquevent&embed=image.url
     slides:
       - 'http://www.slideshare.net/erpla/parisjs-9-phonegap-feedbacks'
     links: []
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - 'https://docs.google.com/present/view?id=dhng4bgf_71c9txhrdb'
     links: []

--- a/content/meetups/2011-08-31.md
+++ b/content/meetups/2011-08-31.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@sgruhier'
         url: 'http://twitter.com/sgruhier'
-        avatar: https://api.microlink.io/?url=https://twitter.com/sgruhier&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/sgruhier&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/sgruhier/brunch-with-coffee'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@chess_at_home'
         url: 'http://twitter.com/chess_at_home'
-        avatar: https://api.microlink.io/?url=https://twitter.com/chess_at_home&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/chess_at_home&amps;embed=image.url
     slides:
       - 'https://docs.google.com/present/view?id=dhpp9dcj_8fxbgxcd5'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@JulienCabanes'
         url: 'http://twitter.com/JulienCabanes'
-        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/JulienZee/parisjs-10-requirejs-9111799'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@mauriz'
         url: 'http://twitter.com/mauriz'
-        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/mauricesvay/parisjs-10-phantomjs'
     links: []
@@ -55,10 +55,10 @@ talks:
     authors:
       - name: '@amorgaut'
         url: 'http://twitter.com/amorgaut'
-        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&amps;embed=image.url
       - name: '@thibarg'
         url: 'http://twitter.com/thibarg'
-        avatar: https://api.microlink.io/?url=https://twitter.com/thibarg&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/thibarg&amps;embed=image.url
     slides:
       - >-
         http://www.slideshare.net/alexandre_morgaut/state-of-the-art-serverside-javascript-parisjs

--- a/content/meetups/2011-08-31.md
+++ b/content/meetups/2011-08-31.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@sgruhier'
         url: 'http://twitter.com/sgruhier'
-        avatar: https://avatars.io/twitter/sgruhier
+        avatar: https://api.microlink.io/?url=https://twitter.com/sgruhier&embed=image.url
     slides:
       - 'http://www.slideshare.net/sgruhier/brunch-with-coffee'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@chess_at_home'
         url: 'http://twitter.com/chess_at_home'
-        avatar: https://avatars.io/twitter/chess_at_home
+        avatar: https://api.microlink.io/?url=https://twitter.com/chess_at_home&embed=image.url
     slides:
       - 'https://docs.google.com/present/view?id=dhpp9dcj_8fxbgxcd5'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@JulienCabanes'
         url: 'http://twitter.com/JulienCabanes'
-        avatar: https://avatars.io/twitter/JulienCabanes
+        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&embed=image.url
     slides:
       - 'http://www.slideshare.net/JulienZee/parisjs-10-requirejs-9111799'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@mauriz'
         url: 'http://twitter.com/mauriz'
-        avatar: https://avatars.io/twitter/mauriz
+        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&embed=image.url
     slides:
       - 'http://www.slideshare.net/mauricesvay/parisjs-10-phantomjs'
     links: []
@@ -55,10 +55,10 @@ talks:
     authors:
       - name: '@amorgaut'
         url: 'http://twitter.com/amorgaut'
-        avatar: https://avatars.io/twitter/amorgaut
+        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&embed=image.url
       - name: '@thibarg'
         url: 'http://twitter.com/thibarg'
-        avatar: https://avatars.io/twitter/thibarg
+        avatar: https://api.microlink.io/?url=https://twitter.com/thibarg&embed=image.url
     slides:
       - >-
         http://www.slideshare.net/alexandre_morgaut/state-of-the-art-serverside-javascript-parisjs

--- a/content/meetups/2011-09-28.md
+++ b/content/meetups/2011-09-28.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - 'https://docs.google.com/present/view?id=dhng4bgf_72dg8qqjcp&pli=1'
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: '@JulienCabanes'
         url: 'http://twitter.com/JulienCabanes'
-        avatar: https://avatars.io/twitter/JulienCabanes
+        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&embed=image.url
     slides:
       - 'http://www.slideshare.net/JulienZee/parisjs-11-sass-compass-9472811'
     links: []
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: '@tchak13'
         url: 'http://twitter.com/tchak13'
-        avatar: 'https://avatars.io/twitter/tchak13'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&embed=image.url'
     slides:
       - 'http://sproutcore20-new-beggining.tchak.net/'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://avatars.io/twitter/sylvinus
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
     slides:
       - 'http://www.slideshare.net/3rdEden/going-real-time-with-socketio'
     links: []

--- a/content/meetups/2011-09-28.md
+++ b/content/meetups/2011-09-28.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - 'https://docs.google.com/present/view?id=dhng4bgf_72dg8qqjcp&pli=1'
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: '@JulienCabanes'
         url: 'http://twitter.com/JulienCabanes'
-        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/JulienZee/parisjs-11-sass-compass-9472811'
     links: []
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: '@tchak13'
         url: 'http://twitter.com/tchak13'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&amps;embed=image.url'
     slides:
       - 'http://sproutcore20-new-beggining.tchak.net/'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/3rdEden/going-real-time-with-socketio'
     links: []

--- a/content/meetups/2011-10-26.md
+++ b/content/meetups/2011-10-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@brmichel'
         url: 'http://twitter.com/brmichel'
-        avatar: https://api.microlink.io/?url=https://twitter.com/brmichel&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/brmichel&amps;embed=image.url
     slides:
       - >-
         http://www.google.com/url?sa=D&q=http://nono.github.com/Presentations/20111026_10_projects_JS/&usg=AFQjCNFuFlzWJEIYV0vEHulo-FJs0wFk0A
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&amps;embed=image.url
     slides:
       - >-
         http://www.google.com/url?sa=D&q=http://www.slideshare.net/sylvinus/140bytes-the-dark-side-of-javascript&usg=AFQjCNE8m-rKR7wOktuTTNnVvCsC0gIGYA
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: '@theystolemynick'
         url: 'http://twitter.com/theystolemynick'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/theystolemynick&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/theystolemynick&amps;embed=image.url'
     slides:
       - 'http://braincracking.org/portfolio/presentation/win8/'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - >-
         http://www.google.com/url?sa=D&q=https://docs.google.com/present/view%3Fid%3Ddhng4bgf_77fkzsn9dt&usg=AFQjCNHwFduDSLogTln8WTzb5_tMtI5UgA
@@ -63,10 +63,10 @@ talks:
     authors:
       - name: '@bobylito'
         url: 'http://twitter.com/bobylito'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&amps;embed=image.url'
       - name: '@42loops'
         url: 'http://twitter.com/42loops'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&amps;embed=image.url'
     slides:
       - 'http://bobylito.github.com/ParisJS12-Intro/presentation.html'
     links: []
@@ -77,7 +77,7 @@ talks:
     authors:
       - name: '@gozala'
         url: 'http://twitter.com/gozala'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/gozala&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gozala&amps;embed=image.url'
     slides:
       - 'http://speakerdeck.com/u/gozala/p/streamer-vs-spaghetti-ninjas'
     links: []
@@ -90,7 +90,7 @@ talks:
     authors:
       - name: '@anotherlin'
         url: 'http://twitter.com/anotherlin'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/anotherlin&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/anotherlin&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2011-10-26.md
+++ b/content/meetups/2011-10-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@brmichel'
         url: 'http://twitter.com/brmichel'
-        avatar: https://avatars.io/twitter/brmichel
+        avatar: https://api.microlink.io/?url=https://twitter.com/brmichel&embed=image.url
     slides:
       - >-
         http://www.google.com/url?sa=D&q=http://nono.github.com/Presentations/20111026_10_projects_JS/&usg=AFQjCNFuFlzWJEIYV0vEHulo-FJs0wFk0A
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: '@sylvinus'
         url: 'http://twitter.com/sylvinus'
-        avatar: https://avatars.io/twitter/sylvinus
+        avatar: https://api.microlink.io/?url=https://twitter.com/sylvinus&embed=image.url
     slides:
       - >-
         http://www.google.com/url?sa=D&q=http://www.slideshare.net/sylvinus/140bytes-the-dark-side-of-javascript&usg=AFQjCNE8m-rKR7wOktuTTNnVvCsC0gIGYA
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: '@theystolemynick'
         url: 'http://twitter.com/theystolemynick'
-        avatar: 'https://avatars.io/twitter/theystolemynick'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/theystolemynick&embed=image.url'
     slides:
       - 'http://braincracking.org/portfolio/presentation/win8/'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - >-
         http://www.google.com/url?sa=D&q=https://docs.google.com/present/view%3Fid%3Ddhng4bgf_77fkzsn9dt&usg=AFQjCNHwFduDSLogTln8WTzb5_tMtI5UgA
@@ -63,10 +63,10 @@ talks:
     authors:
       - name: '@bobylito'
         url: 'http://twitter.com/bobylito'
-        avatar: 'https://avatars.io/twitter/bobylito'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url'
       - name: '@42loops'
         url: 'http://twitter.com/42loops'
-        avatar: 'https://avatars.io/twitter/42loops'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&embed=image.url'
     slides:
       - 'http://bobylito.github.com/ParisJS12-Intro/presentation.html'
     links: []
@@ -77,7 +77,7 @@ talks:
     authors:
       - name: '@gozala'
         url: 'http://twitter.com/gozala'
-        avatar: 'https://avatars.io/twitter/gozala'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gozala&embed=image.url'
     slides:
       - 'http://speakerdeck.com/u/gozala/p/streamer-vs-spaghetti-ninjas'
     links: []
@@ -90,7 +90,7 @@ talks:
     authors:
       - name: '@anotherlin'
         url: 'http://twitter.com/anotherlin'
-        avatar: 'https://avatars.io/twitter/anotherlin'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/anotherlin&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2011-11-30.md
+++ b/content/meetups/2011-11-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@erwan'
         url: 'http://twitter.com/erwan'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/erwan&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/erwan&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/erwanl/paris-js-extensions'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@hexapode'
         url: 'http://twitter.com/hexapode'
-        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&amps;embed=image.url
     slides:
       - 'http://pierreloicdoulcet.fr/slides/parisjs13/#/'
     links: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&amps;embed=image.url'
     slides:
       - 'http://www.b2bweb.fr/bonus/my-book-readr/'
     links: []
@@ -58,7 +58,7 @@ talks:
     authors:
       - name: '@jbrwk'
         url: 'https://twitter.com/jbrwk'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jbrwk&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jbrwk&amps;embed=image.url
     slides:
       - null
     links: []
@@ -69,10 +69,10 @@ talks:
     authors:
       - name: '@tchak13'
         url: 'http://twitter.com/tchak13'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&amps;embed=image.url'
       - name: '@goldledoigt'
         url: 'https://twitter.com/goldledoigt'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/goldledoigt&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/goldledoigt&amps;embed=image.url'
     slides: []
     links:
       - 'http://goldledoigt.github.com/sproutcha/'
@@ -83,7 +83,7 @@ talks:
     authors:
       - name: '@JulienCabanes'
         url: 'http://twitter.com/JulienCabanes'
-        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&amps;embed=image.url
     slides: []
     links:
       - 'https://github.com/ZeeAgency/jquery.htmlize'

--- a/content/meetups/2011-11-30.md
+++ b/content/meetups/2011-11-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@erwan'
         url: 'http://twitter.com/erwan'
-        avatar: 'https://avatars.io/twitter/erwan'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/erwan&embed=image.url'
     slides:
       - 'http://www.slideshare.net/erwanl/paris-js-extensions'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@hexapode'
         url: 'http://twitter.com/hexapode'
-        avatar: https://avatars.io/twitter/hexapode
+        avatar: https://api.microlink.io/?url=https://twitter.com/hexapode&embed=image.url
     slides:
       - 'http://pierreloicdoulcet.fr/slides/parisjs13/#/'
     links: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: 'https://avatars.io/twitter/molokoloco'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url'
     slides:
       - 'http://www.b2bweb.fr/bonus/my-book-readr/'
     links: []
@@ -58,7 +58,7 @@ talks:
     authors:
       - name: '@jbrwk'
         url: 'https://twitter.com/jbrwk'
-        avatar: https://avatars.io/twitter/jbrwk
+        avatar: https://api.microlink.io/?url=https://twitter.com/jbrwk&embed=image.url
     slides:
       - null
     links: []
@@ -69,10 +69,10 @@ talks:
     authors:
       - name: '@tchak13'
         url: 'http://twitter.com/tchak13'
-        avatar: 'https://avatars.io/twitter/tchak13'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&embed=image.url'
       - name: '@goldledoigt'
         url: 'https://twitter.com/goldledoigt'
-        avatar: 'https://avatars.io/twitter/goldledoigt'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/goldledoigt&embed=image.url'
     slides: []
     links:
       - 'http://goldledoigt.github.com/sproutcha/'
@@ -83,7 +83,7 @@ talks:
     authors:
       - name: '@JulienCabanes'
         url: 'http://twitter.com/JulienCabanes'
-        avatar: https://avatars.io/twitter/JulienCabanes
+        avatar: https://api.microlink.io/?url=https://twitter.com/JulienCabanes&embed=image.url
     slides: []
     links:
       - 'https://github.com/ZeeAgency/jquery.htmlize'

--- a/content/meetups/2011-12-21.md
+++ b/content/meetups/2011-12-21.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - 'http://jeromeetienne.github.com/slides-3jsbp-parisjs14'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@shinuza'
         url: 'https://twitter.com/shinuza'
-        avatar: https://avatars.io/twitter/shinuza
+        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&embed=image.url
     slides:
       - 'http://noledgedis.com/slides/extending_nodejs_with_c++.zip'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@eric_brechemier'
         url: 'http://twitter.com/eric_brechemier'
-        avatar: https://avatars.io/twitter/eric_brechemier
+        avatar: https://api.microlink.io/?url=https://twitter.com/eric_brechemier&embed=image.url
     slides:
       - 'http://www.slideshare.net/ericbrechemier/scope-or-not'
     links: []
@@ -44,10 +44,10 @@ talks:
     authors:
       - name: '@amorgaut'
         url: 'http://twitter.com/amorgaut'
-        avatar: https://avatars.io/twitter/amorgaut
+        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&embed=image.url
       - name: '@ThibArg'
         url: 'https://twitter.com/ThibArg'
-        avatar: https://avatars.io/twitter/ThibArg
+        avatar: https://api.microlink.io/?url=https://twitter.com/ThibArg&embed=image.url
     slides:
       - 'http://www.slideshare.net/ThibArg/wakanda-db-parisjs201112'
     links: []

--- a/content/meetups/2011-12-21.md
+++ b/content/meetups/2011-12-21.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - 'http://jeromeetienne.github.com/slides-3jsbp-parisjs14'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@shinuza'
         url: 'https://twitter.com/shinuza'
-        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&amps;embed=image.url
     slides:
       - 'http://noledgedis.com/slides/extending_nodejs_with_c++.zip'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: '@eric_brechemier'
         url: 'http://twitter.com/eric_brechemier'
-        avatar: https://api.microlink.io/?url=https://twitter.com/eric_brechemier&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/eric_brechemier&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/ericbrechemier/scope-or-not'
     links: []
@@ -44,10 +44,10 @@ talks:
     authors:
       - name: '@amorgaut'
         url: 'http://twitter.com/amorgaut'
-        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/amorgaut&amps;embed=image.url
       - name: '@ThibArg'
         url: 'https://twitter.com/ThibArg'
-        avatar: https://api.microlink.io/?url=https://twitter.com/ThibArg&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/ThibArg&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/ThibArg/wakanda-db-parisjs201112'
     links: []

--- a/content/meetups/2012-01-25.md
+++ b/content/meetups/2012-01-25.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides:
       - 'http://jeromeetienne.github.com/slides-boilerplate-builder'
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: '@sgruhier'
         url: 'http://twitter.com/sgruhier'
-        avatar: https://avatars.io/twitter/sgruhier
+        avatar: https://api.microlink.io/?url=https://twitter.com/sgruhier&embed=image.url
     slides:
       - 'http://speakerdeck.com/u/sgruhier/p/coffeescript'
     links: []
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: '@Trigrou'
         url: 'http://twitter.com/trigrou'
-        avatar: 'https://avatars.io/twitter/trigrou'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&embed=image.url'
     slides:
       - 'http://cedricpinson.com/nouvellevague/conf/'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: '@shinuza'
         url: 'http://twitter.com/shinuza'
-        avatar: https://avatars.io/twitter/shinuza
+        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&embed=image.url
     slides:
       - 'http://noledgedis.com/slides/tdd_and_javascript'
     links: []
@@ -63,7 +63,7 @@ talks:
     authors:
       - name: '@d_thevenin'
         url: 'http://twitter.com/d_thevenin'
-        avatar: https://avatars.io/twitter/d_thevenin
+        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&embed=image.url
     slides:
       - 'http://vinisketch.fr/prez/ParisJS15/'
     links: []

--- a/content/meetups/2012-01-25.md
+++ b/content/meetups/2012-01-25.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides:
       - 'http://jeromeetienne.github.com/slides-boilerplate-builder'
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: '@sgruhier'
         url: 'http://twitter.com/sgruhier'
-        avatar: https://api.microlink.io/?url=https://twitter.com/sgruhier&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/sgruhier&amps;embed=image.url
     slides:
       - 'http://speakerdeck.com/u/sgruhier/p/coffeescript'
     links: []
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: '@Trigrou'
         url: 'http://twitter.com/trigrou'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&amps;embed=image.url'
     slides:
       - 'http://cedricpinson.com/nouvellevague/conf/'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: '@shinuza'
         url: 'http://twitter.com/shinuza'
-        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&amps;embed=image.url
     slides:
       - 'http://noledgedis.com/slides/tdd_and_javascript'
     links: []
@@ -63,7 +63,7 @@ talks:
     authors:
       - name: '@d_thevenin'
         url: 'http://twitter.com/d_thevenin'
-        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/d_thevenin&amps;embed=image.url
     slides:
       - 'http://vinisketch.fr/prez/ParisJS15/'
     links: []

--- a/content/meetups/2012-02-29.md
+++ b/content/meetups/2012-02-29.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@XCambar'
         url: 'http://twitter.com/xcambar'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/xcambar&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/xcambar&amps;embed=image.url'
     slides:
       - null
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: '@mauriz'
         url: 'http://twitter.com/mauriz'
-        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/mauricesvay/hacking-rfid-with-nodejs'
     links: []
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: '@Trigrou'
         url: 'http://twitter.com/trigrou'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&amps;embed=image.url'
     slides:
       - null
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: '@tbassetto'
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/tbassetto/web-components-shadow-dom'
     links: []

--- a/content/meetups/2012-02-29.md
+++ b/content/meetups/2012-02-29.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@XCambar'
         url: 'http://twitter.com/xcambar'
-        avatar: 'https://avatars.io/twitter/xcambar'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/xcambar&embed=image.url'
     slides:
       - null
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: '@mauriz'
         url: 'http://twitter.com/mauriz'
-        avatar: https://avatars.io/twitter/mauriz
+        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&embed=image.url
     slides:
       - 'http://www.slideshare.net/mauricesvay/hacking-rfid-with-nodejs'
     links: []
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: '@Trigrou'
         url: 'http://twitter.com/trigrou'
-        avatar: 'https://avatars.io/twitter/trigrou'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/trigrou&embed=image.url'
     slides:
       - null
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: '@tbassetto'
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://avatars.io/twitter/tbassetto'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
     slides:
       - 'http://www.slideshare.net/tbassetto/web-components-shadow-dom'
     links: []

--- a/content/meetups/2012-03-28.md
+++ b/content/meetups/2012-03-28.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@Shinuza'
         url: 'http://twitter.com/shinuza'
-        avatar: https://avatars.io/twitter/shinuza
+        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&embed=image.url
     slides:
       - 'http://t.co/8ogiFLLj'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@Tchak13'
         url: 'http://twitter.com/tchak13'
-        avatar: 'https://avatars.io/twitter/tchak13'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&embed=image.url'
     slides:
       - 'http://speakerdeck.com/u/tchak/p/emberjs'
     links: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: '@florianharmel'
         url: 'http://twitter.com/florianharmel'
-        avatar: https://avatars.io/twitter/florianharmel
+        avatar: https://api.microlink.io/?url=https://twitter.com/florianharmel&embed=image.url
     slides:
       - 'http://www.slideshare.net/florianharmel/snapyx-parisjs'
     links: []

--- a/content/meetups/2012-03-28.md
+++ b/content/meetups/2012-03-28.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@Shinuza'
         url: 'http://twitter.com/shinuza'
-        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/shinuza&amps;embed=image.url
     slides:
       - 'http://t.co/8ogiFLLj'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@Tchak13'
         url: 'http://twitter.com/tchak13'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tchak13&amps;embed=image.url'
     slides:
       - 'http://speakerdeck.com/u/tchak/p/emberjs'
     links: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: '@florianharmel'
         url: 'http://twitter.com/florianharmel'
-        avatar: https://api.microlink.io/?url=https://twitter.com/florianharmel&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/florianharmel&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/florianharmel/snapyx-parisjs'
     links: []

--- a/content/meetups/2012-04-16.md
+++ b/content/meetups/2012-04-16.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@francoisz'
         url: 'https://twitter.com/francoisz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/francoisz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francoisz&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/francoisz/bonnes-pratiques-node-js'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@Shinuza'
         url: 'https://twitter.com/Shinuza'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Shinuza&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Shinuza&amps;embed=image.url'
     slides:
       - >-
         http://noledgedis.com/slides/en_route_pour_node-v0.8.0/assets/fallback/index.html
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'https://twitter.com/francois2metz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&amps;embed=image.url'
     slides:
       - 'http://francois2metz.github.com/showoff-nodejs/'
     links: []
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: '@steren'
         url: 'https://twitter.com/steren'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/steren&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/steren&amps;embed=image.url'
     slides:
       - >-
         http://www.slideshare.net/sterengiannini/joshfire-factory-using-nodejs-in-production
@@ -57,7 +57,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'https://twitter.com/francois2metz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&amps;embed=image.url'
     slides:
       - 'http://codestre.am/f20ee7b2aadfb13755f6f54ca'
     links: []
@@ -68,7 +68,7 @@ talks:
     authors:
       - name: '@a_thieriot'
         url: 'https://twitter.com/a_thieriot'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/a_thieriot&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/a_thieriot&amps;embed=image.url'
     slides:
       - 'http://athieriot.github.com/wing-commander-js/'
     links: []

--- a/content/meetups/2012-04-16.md
+++ b/content/meetups/2012-04-16.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: '@francoisz'
         url: 'https://twitter.com/francoisz'
-        avatar: 'https://avatars.io/twitter/francoisz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francoisz&embed=image.url'
     slides:
       - 'http://www.slideshare.net/francoisz/bonnes-pratiques-node-js'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@Shinuza'
         url: 'https://twitter.com/Shinuza'
-        avatar: 'https://avatars.io/twitter/Shinuza'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Shinuza&embed=image.url'
     slides:
       - >-
         http://noledgedis.com/slides/en_route_pour_node-v0.8.0/assets/fallback/index.html
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'https://twitter.com/francois2metz'
-        avatar: 'https://avatars.io/twitter/francois2metz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
     slides:
       - 'http://francois2metz.github.com/showoff-nodejs/'
     links: []
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: '@steren'
         url: 'https://twitter.com/steren'
-        avatar: 'https://avatars.io/twitter/steren'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/steren&embed=image.url'
     slides:
       - >-
         http://www.slideshare.net/sterengiannini/joshfire-factory-using-nodejs-in-production
@@ -57,7 +57,7 @@ talks:
     authors:
       - name: '@francois2metz'
         url: 'https://twitter.com/francois2metz'
-        avatar: 'https://avatars.io/twitter/francois2metz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francois2metz&embed=image.url'
     slides:
       - 'http://codestre.am/f20ee7b2aadfb13755f6f54ca'
     links: []
@@ -68,7 +68,7 @@ talks:
     authors:
       - name: '@a_thieriot'
         url: 'https://twitter.com/a_thieriot'
-        avatar: 'https://avatars.io/twitter/a_thieriot'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/a_thieriot&embed=image.url'
     slides:
       - 'http://athieriot.github.com/wing-commander-js/'
     links: []

--- a/content/meetups/2012-05-30.md
+++ b/content/meetups/2012-05-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: https://avatars.io/twitter/molokoloco
+        avatar: https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url
     slides: []
     links: []
     videos: []
@@ -21,7 +21,7 @@ talks:
     authors:
       - name: '@Tchak13'
         url: 'http://twitter.com/tchak13'
-        avatar: https://avatars.io/twitter/tchak13
+        avatar: https://api.microlink.io/?url=https://twitter.com/tchak13&embed=image.url
     slides:
       - 'https://speakerdeck.com/u/tchak/p/ember-data'
     links: []
@@ -32,7 +32,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'https://twitter.com/Dj3bbZ'
-        avatar: 'https://avatars.io/twitter/Dj3bbZ'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: David Catuhe
         url: 'https://twitter.com/deltakosh'
-        avatar: 'https://avatars.io/twitter/deltakosh'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/deltakosh&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2012-05-30.md
+++ b/content/meetups/2012-05-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/molokoloco&amps;embed=image.url
     slides: []
     links: []
     videos: []
@@ -21,7 +21,7 @@ talks:
     authors:
       - name: '@Tchak13'
         url: 'http://twitter.com/tchak13'
-        avatar: https://api.microlink.io/?url=https://twitter.com/tchak13&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/tchak13&amps;embed=image.url
     slides:
       - 'https://speakerdeck.com/u/tchak/p/ember-data'
     links: []
@@ -32,7 +32,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'https://twitter.com/Dj3bbZ'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: David Catuhe
         url: 'https://twitter.com/deltakosh'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/deltakosh&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/deltakosh&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2012-06-27.md
+++ b/content/meetups/2012-06-27.md
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@revolunet'
         url: 'http://twitter.com/revolunet'
-        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&amps;embed=image.url
     slides: []
     links: []
     videos: []
@@ -54,7 +54,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url
     slides: []
     links: []
     videos: []

--- a/content/meetups/2012-06-27.md
+++ b/content/meetups/2012-06-27.md
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: '@revolunet'
         url: 'http://twitter.com/revolunet'
-        avatar: https://avatars.io/twitter/revolunet
+        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&embed=image.url
     slides: []
     links: []
     videos: []
@@ -54,7 +54,7 @@ talks:
     authors:
       - name: '@jerome_etienne'
         url: 'http://twitter.com/jerome_etienne'
-        avatar: https://avatars.io/twitter/jerome_etienne
+        avatar: https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url
     slides: []
     links: []
     videos: []

--- a/content/meetups/2012-07-25.md
+++ b/content/meetups/2012-07-25.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Mathieu Robin
         url: 'http://twitter.com/mathrobin'
-        avatar: https://api.microlink.io/?url=https://twitter.com/mathrobin&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/mathrobin&amps;embed=image.url
     slides:
       - 'http://www.slideshare.net/mathrobin/construire-un-plugin-pour-jquery-15'
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: Samuel Ronce
         url: 'http://twitter.com/webcreative5'
-        avatar: https://api.microlink.io/?url=https://twitter.com/webcreative5&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/webcreative5&amps;embed=image.url
     slides: []
     links: []
     videos:
@@ -36,7 +36,7 @@ talks:
     authors:
       - name: Thomas Bassetto
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&amps;embed=image.url'
     slides: []
     links: []
     videos:
@@ -51,7 +51,7 @@ talks:
     authors:
       - name: Franck Ernewein
         url: 'http://twitter.com/FranckErnewein'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/FranckErnewein&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/FranckErnewein&amps;embed=image.url'
     slides: []
     links: []
     videos:
@@ -63,7 +63,7 @@ talks:
     authors:
       - name: Stanislas Polu
         url: 'http://twitter.com/spolu'
-        avatar: https://api.microlink.io/?url=https://twitter.com/spolu&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/spolu&amps;embed=image.url
     slides: []
     links: []
     videos:

--- a/content/meetups/2012-07-25.md
+++ b/content/meetups/2012-07-25.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Mathieu Robin
         url: 'http://twitter.com/mathrobin'
-        avatar: https://avatars.io/twitter/mathrobin
+        avatar: https://api.microlink.io/?url=https://twitter.com/mathrobin&embed=image.url
     slides:
       - 'http://www.slideshare.net/mathrobin/construire-un-plugin-pour-jquery-15'
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: Samuel Ronce
         url: 'http://twitter.com/webcreative5'
-        avatar: https://avatars.io/twitter/webcreative5
+        avatar: https://api.microlink.io/?url=https://twitter.com/webcreative5&embed=image.url
     slides: []
     links: []
     videos:
@@ -36,7 +36,7 @@ talks:
     authors:
       - name: Thomas Bassetto
         url: 'http://twitter.com/tbassetto'
-        avatar: 'https://avatars.io/twitter/tbassetto'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tbassetto&embed=image.url'
     slides: []
     links: []
     videos:
@@ -51,7 +51,7 @@ talks:
     authors:
       - name: Franck Ernewein
         url: 'http://twitter.com/FranckErnewein'
-        avatar: 'https://avatars.io/twitter/FranckErnewein'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/FranckErnewein&embed=image.url'
     slides: []
     links: []
     videos:
@@ -63,7 +63,7 @@ talks:
     authors:
       - name: Stanislas Polu
         url: 'http://twitter.com/spolu'
-        avatar: https://avatars.io/twitter/spolu
+        avatar: https://api.microlink.io/?url=https://twitter.com/spolu&embed=image.url
     slides: []
     links: []
     videos:

--- a/content/meetups/2012-09-26.md
+++ b/content/meetups/2012-09-26.md
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: Evan Génieur
         url: 'http://twitter.com/evangenieur'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/evangenieur&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/evangenieur&amps;embed=image.url'
     slides: []
     links: []
     videos:
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: Xavier Cambar
         url: 'https://twitter.com/xcambar'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/xcambar&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/xcambar&amps;embed=image.url'
     slides:
       - 'http://xcambar.github.com/parisjs_22/#/intro'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: Maurice Svay
         url: 'http://twitter.com/mauriz'
-        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&amps;embed=image.url
     slides:
       - 'https://speakerdeck.com/u/mauricesvay/p/imageresolver-dot-js'
     links: []
@@ -63,7 +63,7 @@ talks:
     authors:
       - name: Emmanuel Remy
         url: 'https://twitter.com/manuremy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&amps;embed=image.url'
     slides: []
     links: []
     videos:
@@ -75,7 +75,7 @@ talks:
     authors:
       - name: Mathieu Robin
         url: 'http://twitter.com/mathrobin'
-        avatar: https://api.microlink.io/?url=https://twitter.com/mathrobin&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/mathrobin&amps;embed=image.url
     slides:
       - 'https://gist.github.com/3778385'
     links: []

--- a/content/meetups/2012-09-26.md
+++ b/content/meetups/2012-09-26.md
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: Evan Génieur
         url: 'http://twitter.com/evangenieur'
-        avatar: 'https://avatars.io/twitter/evangenieur'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/evangenieur&embed=image.url'
     slides: []
     links: []
     videos:
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: Xavier Cambar
         url: 'https://twitter.com/xcambar'
-        avatar: 'https://avatars.io/twitter/xcambar'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/xcambar&embed=image.url'
     slides:
       - 'http://xcambar.github.com/parisjs_22/#/intro'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: Maurice Svay
         url: 'http://twitter.com/mauriz'
-        avatar: https://avatars.io/twitter/mauriz
+        avatar: https://api.microlink.io/?url=https://twitter.com/mauriz&embed=image.url
     slides:
       - 'https://speakerdeck.com/u/mauricesvay/p/imageresolver-dot-js'
     links: []
@@ -63,7 +63,7 @@ talks:
     authors:
       - name: Emmanuel Remy
         url: 'https://twitter.com/manuremy'
-        avatar: 'https://avatars.io/twitter/manuremy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
     slides: []
     links: []
     videos:
@@ -75,7 +75,7 @@ talks:
     authors:
       - name: Mathieu Robin
         url: 'http://twitter.com/mathrobin'
-        avatar: https://avatars.io/twitter/mathrobin
+        avatar: https://api.microlink.io/?url=https://twitter.com/mathrobin&embed=image.url
     slides:
       - 'https://gist.github.com/3778385'
     links: []

--- a/content/meetups/2012-10-31.md
+++ b/content/meetups/2012-10-31.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Alexis Jacomy
         url: 'https://twitter.com/jacomyal'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jacomyal&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jacomyal&amps;embed=image.url
     slides: []
     links: []
     videos:
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Emmanuel REMY
         url: 'https://twitter.com/manuremy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2012-10-31.md
+++ b/content/meetups/2012-10-31.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Alexis Jacomy
         url: 'https://twitter.com/jacomyal'
-        avatar: https://avatars.io/twitter/jacomyal
+        avatar: https://api.microlink.io/?url=https://twitter.com/jacomyal&embed=image.url
     slides: []
     links: []
     videos:
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Emmanuel REMY
         url: 'https://twitter.com/manuremy'
-        avatar: 'https://avatars.io/twitter/manuremy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2012-11-28.md
+++ b/content/meetups/2012-11-28.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'https://twitter.com/Dj3bbZ'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&amps;embed=image.url'
     slides:
       - 'http://www.rvl.io/djebbz/brunch/'
     links:
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: Patrick Aljord
         url: null
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/patcito&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/patcito&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/patcito/introduction-to-angularjs-15394765'
     links: []
@@ -53,7 +53,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2012-11-28.md
+++ b/content/meetups/2012-11-28.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'https://twitter.com/Dj3bbZ'
-        avatar: 'https://avatars.io/twitter/Dj3bbZ'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
     slides:
       - 'http://www.rvl.io/djebbz/brunch/'
     links:
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: Patrick Aljord
         url: null
-        avatar: 'https://avatars.io/twitter/patcito'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/patcito&embed=image.url'
     slides:
       - 'http://www.slideshare.net/patcito/introduction-to-angularjs-15394765'
     links: []
@@ -53,7 +53,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: 'https://avatars.io/twitter/molokoloco'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2013-01-30.md
+++ b/content/meetups/2013-01-30.md
@@ -27,13 +27,13 @@ talks:
     authors:
       - name: Jean-Laurent Morlhon
         url: 'https://twitter.com/morlhon'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/morlhon&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/morlhon&amps;embed=image.url'
       - name: Benoit Lemoine
         url: 'https://twitter.com/benoit_lemoine'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/benoit_lemoine&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/benoit_lemoine&amps;embed=image.url'
       - name: Mathieu Breton
         url: 'https://twitter.com/MatBreton'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/MatBreton&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/MatBreton&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -43,7 +43,7 @@ talks:
     authors:
       - name: François Zaninotto
         url: 'https://twitter.com/francoisz'
-        avatar: https://api.microlink.io/?url=https://twitter.com/francoisz&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/francoisz&amps;embed=image.url
     slides:
       - >-
         http://dotheweb.posterous.com/functional-testing-for-nodejs-using-mocha-and
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: Marc Bourlon
         url: 'https://github.com/marcbourlon'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/m_a_r_c_b&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/m_a_r_c_b&amps;embed=image.url'
     slides: []
     links:
       - 'https://github.com/marcbourlon/TipTap'

--- a/content/meetups/2013-01-30.md
+++ b/content/meetups/2013-01-30.md
@@ -27,13 +27,13 @@ talks:
     authors:
       - name: Jean-Laurent Morlhon
         url: 'https://twitter.com/morlhon'
-        avatar: 'https://avatars.io/twitter/morlhon'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/morlhon&embed=image.url'
       - name: Benoit Lemoine
         url: 'https://twitter.com/benoit_lemoine'
-        avatar: 'https://avatars.io/twitter/benoit_lemoine'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/benoit_lemoine&embed=image.url'
       - name: Mathieu Breton
         url: 'https://twitter.com/MatBreton'
-        avatar: 'https://avatars.io/twitter/MatBreton'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/MatBreton&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -43,7 +43,7 @@ talks:
     authors:
       - name: François Zaninotto
         url: 'https://twitter.com/francoisz'
-        avatar: https://avatars.io/twitter/francoisz
+        avatar: https://api.microlink.io/?url=https://twitter.com/francoisz&embed=image.url
     slides:
       - >-
         http://dotheweb.posterous.com/functional-testing-for-nodejs-using-mocha-and
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: Marc Bourlon
         url: 'https://github.com/marcbourlon'
-        avatar: 'https://avatars.io/twitter/m_a_r_c_b'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/m_a_r_c_b&embed=image.url'
     slides: []
     links:
       - 'https://github.com/marcbourlon/TipTap'

--- a/content/meetups/2013-02-27.md
+++ b/content/meetups/2013-02-27.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Mathieu Parisot
         url: 'https://twitter.com/matparisot'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/matparisot&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/matparisot&amps;embed=image.url'
     slides:
       - 'http://fr.slideshare.net/soatexpert/prez-dot-jsparisjs27022013'
     links:
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: Cédric Soulas
         url: 'https://twitter.com/CedricSoulas'
-        avatar: https://api.microlink.io/?url=https://twitter.com/CedricSoulas&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/CedricSoulas&amps;embed=image.url
     slides: []
     links:
       - 'http://opalang.org/'

--- a/content/meetups/2013-02-27.md
+++ b/content/meetups/2013-02-27.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Mathieu Parisot
         url: 'https://twitter.com/matparisot'
-        avatar: 'https://avatars.io/twitter/matparisot'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/matparisot&embed=image.url'
     slides:
       - 'http://fr.slideshare.net/soatexpert/prez-dot-jsparisjs27022013'
     links:
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: Cédric Soulas
         url: 'https://twitter.com/CedricSoulas'
-        avatar: https://avatars.io/twitter/CedricSoulas
+        avatar: https://api.microlink.io/?url=https://twitter.com/CedricSoulas&embed=image.url
     slides: []
     links:
       - 'http://opalang.org/'

--- a/content/meetups/2013-03-28.md
+++ b/content/meetups/2013-03-28.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'https://twitter.com/Dj3bbZ'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&amps;embed=image.url'
     slides:
       - 'http://djebbz.github.io/async-paris-js/#/intro'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@42loops'
         url: 'http://twitter.com/42loops'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&amps;embed=image.url'
     slides:
       - 'http://peutetre.github.io/talk-zanimo-parisjs-28/'
     links:

--- a/content/meetups/2013-03-28.md
+++ b/content/meetups/2013-03-28.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'https://twitter.com/Dj3bbZ'
-        avatar: 'https://avatars.io/twitter/Dj3bbZ'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
     slides:
       - 'http://djebbz.github.io/async-paris-js/#/intro'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: '@42loops'
         url: 'http://twitter.com/42loops'
-        avatar: 'https://avatars.io/twitter/42loops'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/42loops&embed=image.url'
     slides:
       - 'http://peutetre.github.io/talk-zanimo-parisjs-28/'
     links:

--- a/content/meetups/2013-04-24.md
+++ b/content/meetups/2013-04-24.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Paul Dijou
         url: 'https://twitter.com/paul_dijou'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/paul_dijou&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/paul_dijou&amps;embed=image.url'
     slides:
       - 'http://pauldijou.fr/ioslides/parisjs/bower'
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: David Rousset
         url: 'https://twitter.com/davrous'
-        avatar: https://api.microlink.io/?url=https://twitter.com/davrous&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/davrous&amps;embed=image.url
     slides:
       - 'http://fr.slideshare.net/davrous/pointer-events'
     links: []
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: Antoine Rogliano
         url: 'https://twitter.com/Inateno'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Inateno&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Inateno&amps;embed=image.url'
     slides:
       - 'http://www.rvl.io/inateno/dream-engine'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: Jean-Philippe Encausse
         url: 'https://twitter.com/JpEncausse'
-        avatar: https://api.microlink.io/?url=https://twitter.com/JpEncausse&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/JpEncausse&amps;embed=image.url
     slides: []
     links: []
     videos:
@@ -64,7 +64,7 @@ talks:
     authors:
       - name: Steren Giannini
         url: 'https://twitter.com/steren'
-        avatar: https://api.microlink.io/?url=https://twitter.com/steren&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/steren&amps;embed=image.url
     slides: []
     links:
       - 'https://gist.github.com/steren/5451051'

--- a/content/meetups/2013-04-24.md
+++ b/content/meetups/2013-04-24.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Paul Dijou
         url: 'https://twitter.com/paul_dijou'
-        avatar: 'https://avatars.io/twitter/paul_dijou'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/paul_dijou&embed=image.url'
     slides:
       - 'http://pauldijou.fr/ioslides/parisjs/bower'
     links: []
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: David Rousset
         url: 'https://twitter.com/davrous'
-        avatar: https://avatars.io/twitter/davrous
+        avatar: https://api.microlink.io/?url=https://twitter.com/davrous&embed=image.url
     slides:
       - 'http://fr.slideshare.net/davrous/pointer-events'
     links: []
@@ -37,7 +37,7 @@ talks:
     authors:
       - name: Antoine Rogliano
         url: 'https://twitter.com/Inateno'
-        avatar: 'https://avatars.io/twitter/Inateno'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Inateno&embed=image.url'
     slides:
       - 'http://www.rvl.io/inateno/dream-engine'
     links: []
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: Jean-Philippe Encausse
         url: 'https://twitter.com/JpEncausse'
-        avatar: https://avatars.io/twitter/JpEncausse
+        avatar: https://api.microlink.io/?url=https://twitter.com/JpEncausse&embed=image.url
     slides: []
     links: []
     videos:
@@ -64,7 +64,7 @@ talks:
     authors:
       - name: Steren Giannini
         url: 'https://twitter.com/steren'
-        avatar: https://avatars.io/twitter/steren
+        avatar: https://api.microlink.io/?url=https://twitter.com/steren&embed=image.url
     slides: []
     links:
       - 'https://gist.github.com/steren/5451051'

--- a/content/meetups/2013-06-26.md
+++ b/content/meetups/2013-06-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Jean-Philippe Encausse
         url: 'https://twitter.com/JpEncausse'
-        avatar: https://avatars.io/twitter/JpEncausse
+        avatar: https://api.microlink.io/?url=https://twitter.com/JpEncausse&embed=image.url
     slides:
       - >-
         https://dl.dropboxusercontent.com/u/255810/Encausse.net/Sarah/conf_brainjs_parisjs.pptx
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: 'https://avatars.io/twitter/molokoloco'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url'
     slides:
       - >-
         https://docs.google.com/document/d/1khVWiDeFj-KY2OhVqbZN_w1aef2iCC0yhhLEdj8p8yY/
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: Alexis Jacomy
         url: 'https://twitter.com/jacomyal'
-        avatar: https://avatars.io/twitter/jacomyal
+        avatar: https://api.microlink.io/?url=https://twitter.com/jacomyal&embed=image.url
     slides:
       - 'http://jacomyal.github.io/parisjs-201306-domino/'
     links: []
@@ -68,7 +68,7 @@ talks:
     authors:
       - name: Thibaud Arnault
         url: 'https://twitter.com/thibaud_arnault'
-        avatar: https://avatars.io/twitter/thibaud_arnault
+        avatar: https://api.microlink.io/?url=https://twitter.com/thibaud_arnault&embed=image.url
     slides:
       - 'http://slid.es/thyb/webshell'
     links: []

--- a/content/meetups/2013-06-26.md
+++ b/content/meetups/2013-06-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Jean-Philippe Encausse
         url: 'https://twitter.com/JpEncausse'
-        avatar: https://api.microlink.io/?url=https://twitter.com/JpEncausse&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/JpEncausse&amps;embed=image.url
     slides:
       - >-
         https://dl.dropboxusercontent.com/u/255810/Encausse.net/Sarah/conf_brainjs_parisjs.pptx
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: Julien Guézennec
         url: 'https://twitter.com/molokoloco'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/molokoloco&amps;embed=image.url'
     slides:
       - >-
         https://docs.google.com/document/d/1khVWiDeFj-KY2OhVqbZN_w1aef2iCC0yhhLEdj8p8yY/
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: Alexis Jacomy
         url: 'https://twitter.com/jacomyal'
-        avatar: https://api.microlink.io/?url=https://twitter.com/jacomyal&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/jacomyal&amps;embed=image.url
     slides:
       - 'http://jacomyal.github.io/parisjs-201306-domino/'
     links: []
@@ -68,7 +68,7 @@ talks:
     authors:
       - name: Thibaud Arnault
         url: 'https://twitter.com/thibaud_arnault'
-        avatar: https://api.microlink.io/?url=https://twitter.com/thibaud_arnault&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/thibaud_arnault&amps;embed=image.url
     slides:
       - 'http://slid.es/thyb/webshell'
     links: []

--- a/content/meetups/2013-10-30.md
+++ b/content/meetups/2013-10-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Marek Kalnik
         url: 'https://twitter.com/marekkalnik'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/marekkalnik&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/marekkalnik&amps;embed=image.url'
     slides:
       - 'https://speakerdeck.com/marekkalnik/write-your-jquery-in-console-1'
     links: []

--- a/content/meetups/2013-10-30.md
+++ b/content/meetups/2013-10-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Marek Kalnik
         url: 'https://twitter.com/marekkalnik'
-        avatar: 'https://avatars.io/twitter/marekkalnik'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/marekkalnik&embed=image.url'
     slides:
       - 'https://speakerdeck.com/marekkalnik/write-your-jquery-in-console-1'
     links: []

--- a/content/meetups/2013-11-20.md
+++ b/content/meetups/2013-11-20.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Frank Rousseau
         url: 'http://twitter.com/mycozycloud'
-        avatar: https://avatars.io/twitter/mycozycloud
+        avatar: https://api.microlink.io/?url=https://twitter.com/mycozycloud&embed=image.url
     slides:
       - 'http://fr.slideshare.net/gelnior/20131120-cozy-parisjs'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: Xavier Bourry
         url: 'http://twitter.com/xavgoo'
-        avatar: 'https://avatars.io/twitter/xavgoo'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/xavgoo&embed=image.url'
     slides:
       - 'http://www.webglacademy.com/presentation'
     links: []

--- a/content/meetups/2013-11-20.md
+++ b/content/meetups/2013-11-20.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Frank Rousseau
         url: 'http://twitter.com/mycozycloud'
-        avatar: https://api.microlink.io/?url=https://twitter.com/mycozycloud&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/mycozycloud&amps;embed=image.url
     slides:
       - 'http://fr.slideshare.net/gelnior/20131120-cozy-parisjs'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: Xavier Bourry
         url: 'http://twitter.com/xavgoo'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/xavgoo&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/xavgoo&amps;embed=image.url'
     slides:
       - 'http://www.webglacademy.com/presentation'
     links: []

--- a/content/meetups/2014-01-29.md
+++ b/content/meetups/2014-01-29.md
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'http://www.twitter.com/dj3bbz'
-        avatar: 'https://avatars.io/twitter/Dj3bbZ'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
     slides: []
     links: []
     videos:
@@ -35,7 +35,7 @@ talks:
     authors:
       - name: François Daoust
         url: 'http://www.twitter.com/tidoust'
-        avatar: 'https://avatars.io/twitter/tidoust'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tidoust&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2014-01-29.md
+++ b/content/meetups/2014-01-29.md
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'http://www.twitter.com/dj3bbz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&amps;embed=image.url'
     slides: []
     links: []
     videos:
@@ -35,7 +35,7 @@ talks:
     authors:
       - name: François Daoust
         url: 'http://www.twitter.com/tidoust'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/tidoust&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/tidoust&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2014-02-26.md
+++ b/content/meetups/2014-02-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'http://twitter.com/Dj3bbZ'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&amps;embed=image.url'
     slides:
       - 'https://github.com/DjebbZ/browserify-paris-js'
     links: []
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Mickael Andrieu
         url: 'http://twitter.com/mickael_andrieu'
-        avatar: https://api.microlink.io/?url=https://twitter.com/mickael_andrieu&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/mickael_andrieu&amps;embed=image.url
     slides:
       - 'http://slid.es/mickaelandrieu/casperjs'
     links: []
@@ -39,7 +39,7 @@ talks:
     authors:
       - name: Emmanuel Remy
         url: 'http://twitter.com/manuremy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2014-02-26.md
+++ b/content/meetups/2014-02-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'http://twitter.com/Dj3bbZ'
-        avatar: 'https://avatars.io/twitter/Dj3bbZ'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Dj3bbZ&embed=image.url'
     slides:
       - 'https://github.com/DjebbZ/browserify-paris-js'
     links: []
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Mickael Andrieu
         url: 'http://twitter.com/mickael_andrieu'
-        avatar: https://avatars.io/twitter/mickael_andrieu
+        avatar: https://api.microlink.io/?url=https://twitter.com/mickael_andrieu&embed=image.url
     slides:
       - 'http://slid.es/mickaelandrieu/casperjs'
     links: []
@@ -39,7 +39,7 @@ talks:
     authors:
       - name: Emmanuel Remy
         url: 'http://twitter.com/manuremy'
-        avatar: 'https://avatars.io/twitter/manuremy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2014-03-26.md
+++ b/content/meetups/2014-03-26.md
@@ -47,7 +47,7 @@ talks:
     authors:
       - name: Gabriel Majoulet
         url: 'http://twitter.com/gmajoulet'
-        avatar: 'https://avatars.io/twitter/gmajoulet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&embed=image.url'
     slides:
       - 'http://fr.slideshare.net/gmajoulet/paris-js35-stratgie-de-tests'
     links: []

--- a/content/meetups/2014-03-26.md
+++ b/content/meetups/2014-03-26.md
@@ -47,7 +47,7 @@ talks:
     authors:
       - name: Gabriel Majoulet
         url: 'http://twitter.com/gmajoulet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&amps;embed=image.url'
     slides:
       - 'http://fr.slideshare.net/gmajoulet/paris-js35-stratgie-de-tests'
     links: []

--- a/content/meetups/2014-09-24.md
+++ b/content/meetups/2014-09-24.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Jonathan Petitcolas
         url: 'https://www.twitter.com/sethpolma'
-        avatar: 'https://avatars.io/twitter/sethpolma'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/sethpolma&embed=image.url'
     slides:
       - >-
         http://www.jonathan-petitcolas.com/talks/2014-09-24-advanced-mint-monitoring/2014-09-24-advanced-mint-monitoring.html
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: Marc Buils
         url: 'http://www.marcbuils.fr/'
-        avatar: 'https://avatars.io/twitter/marcbuils'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/marcbuils&embed=image.url'
     slides:
       - >-
         https://a378e6f5477f6af5ab43f457510a6c436202f44d.googledrive.com/host/0B7E1cle5Q-hIWjA3Q1RrRkVEdm8/presentation/#1

--- a/content/meetups/2014-09-24.md
+++ b/content/meetups/2014-09-24.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Jonathan Petitcolas
         url: 'https://www.twitter.com/sethpolma'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/sethpolma&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/sethpolma&amps;embed=image.url'
     slides:
       - >-
         http://www.jonathan-petitcolas.com/talks/2014-09-24-advanced-mint-monitoring/2014-09-24-advanced-mint-monitoring.html
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: Marc Buils
         url: 'http://www.marcbuils.fr/'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/marcbuils&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/marcbuils&amps;embed=image.url'
     slides:
       - >-
         https://a378e6f5477f6af5ab43f457510a6c436202f44d.googledrive.com/host/0B7E1cle5Q-hIWjA3Q1RrRkVEdm8/presentation/#1

--- a/content/meetups/2014-10-29.md
+++ b/content/meetups/2014-10-29.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Jean-Loup Karst
         url: 'https://twitter.com/jeanloupkarst'
-        avatar: 'https://avatars.io/twitter/jeanloupkarst'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/jeanloupkarst&embed=image.url'
     slides:
       - 'http://blog.breaz.io/2014/10/back-stack-french-tech-inventory/'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: Gabriel Majoulet
         url: 'https://twitter.com/gmajoulet'
-        avatar: 'https://avatars.io/twitter/gmajoulet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&embed=image.url'
     slides:
       - 'http://fr.slideshare.net/gmajoulet/parisjs-40-deezer-france'
     links: []
@@ -35,7 +35,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'https://twitter.com/dj3bbz'
-        avatar: 'https://avatars.io/twitter/dj3bbz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/dj3bbz&embed=image.url'
     slides: []
     links:
       - 'https://github.com/DjebbZ/gss-paris-js'
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://avatars.io/twitter/harrisfreddy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
     slides:
       - 'http://freddy03h.github.io/hello-presentation/#/'
     links: []

--- a/content/meetups/2014-10-29.md
+++ b/content/meetups/2014-10-29.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Jean-Loup Karst
         url: 'https://twitter.com/jeanloupkarst'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/jeanloupkarst&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/jeanloupkarst&amps;embed=image.url'
     slides:
       - 'http://blog.breaz.io/2014/10/back-stack-french-tech-inventory/'
     links: []
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: Gabriel Majoulet
         url: 'https://twitter.com/gmajoulet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&amps;embed=image.url'
     slides:
       - 'http://fr.slideshare.net/gmajoulet/parisjs-40-deezer-france'
     links: []
@@ -35,7 +35,7 @@ talks:
     authors:
       - name: Khalid Jebbari
         url: 'https://twitter.com/dj3bbz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/dj3bbz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/dj3bbz&amps;embed=image.url'
     slides: []
     links:
       - 'https://github.com/DjebbZ/gss-paris-js'
@@ -50,7 +50,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&amps;embed=image.url'
     slides:
       - 'http://freddy03h.github.io/hello-presentation/#/'
     links: []

--- a/content/meetups/2014-11-26.md
+++ b/content/meetups/2014-11-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Laurent Perrin
         url: 'https://twitter.com/l_perrin'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/l_perrin&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/l_perrin&amps;embed=image.url'
     slides:
       - 'https://github.com/lperrin/talk-contenteditable'
     links:
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Jacopo Daeli
         url: 'http://www.jacopodaeli.com'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: Alexandre Stanislawski
         url: 'https://twitter.com/bobylito'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&amps;embed=image.url'
     slides:
       - 'https://speakerdeck.com/bobylito/react-and-games'
     links:

--- a/content/meetups/2014-11-26.md
+++ b/content/meetups/2014-11-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Laurent Perrin
         url: 'https://twitter.com/l_perrin'
-        avatar: 'https://avatars.io/twitter/l_perrin'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/l_perrin&embed=image.url'
     slides:
       - 'https://github.com/lperrin/talk-contenteditable'
     links:
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Jacopo Daeli
         url: 'http://www.jacopodaeli.com'
-        avatar: 'https://avatars.io/twitter/JacopoDaeli'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: Alexandre Stanislawski
         url: 'https://twitter.com/bobylito'
-        avatar: 'https://avatars.io/twitter/bobylito'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url'
     slides:
       - 'https://speakerdeck.com/bobylito/react-and-games'
     links:

--- a/content/meetups/2015-01-21.md
+++ b/content/meetups/2015-01-21.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Maël Nison
         url: 'https://twitter.com/arcanis'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&amps;embed=image.url'
     slides: []
     links:
       - 'http://m.start9.io'
@@ -64,7 +64,7 @@ talks:
     authors:
       - name: Christophe Porteneuve
         url: 'https://twitter.com/porteneuve'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/porteneuve&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/porteneuve&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -88,7 +88,7 @@ talks:
     authors:
       - name: Cédric Lombardot
         url: 'https://twitter.com/cedriclombardot'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/cedriclombardot&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/cedriclombardot&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2015-01-21.md
+++ b/content/meetups/2015-01-21.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Maël Nison
         url: 'https://twitter.com/arcanis'
-        avatar: 'https://avatars.io/twitter/arcanis'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&embed=image.url'
     slides: []
     links:
       - 'http://m.start9.io'
@@ -64,7 +64,7 @@ talks:
     authors:
       - name: Christophe Porteneuve
         url: 'https://twitter.com/porteneuve'
-        avatar: 'https://avatars.io/twitter/porteneuve'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/porteneuve&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -88,7 +88,7 @@ talks:
     authors:
       - name: Cédric Lombardot
         url: 'https://twitter.com/cedriclombardot'
-        avatar: 'https://avatars.io/twitter/cedriclombardot'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/cedriclombardot&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2015-02-26.md
+++ b/content/meetups/2015-02-26.md
@@ -15,7 +15,7 @@ talks:
     authors:
       - name: Hugo Cordier
         url: 'https://twitter.com/HugoCrd'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/HugoCrd&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/HugoCrd&amps;embed=image.url'
     slides:
       - >-
         https://speakerdeck.com/hugocrd/functional-reactive-programming-with-rxjs
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: Alexandre 'bobylito' Stanislawski
         url: 'https://twitter.com/bobylito'
-        avatar: https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/bobylito&amps;embed=image.url
     slides:
       - 'https://speakerdeck.com/bobylito/the-promise-and-the-hack'
     links: []
@@ -48,7 +48,7 @@ talks:
     authors:
       - name: Julien 'revolunet' Bouquillon
         url: 'https://twitter.com/revolunet'
-        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&amps;embed=image.url
     slides:
       - 'http://blog.revolunet.com/angular-react-meetup/'
     links:
@@ -70,7 +70,7 @@ talks:
     authors:
       - name: Gaspard Beernaert
         url: 'https://twitter.com/freelancis'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/freelancis&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/freelancis&amps;embed=image.url'
     slides:
       - 'http://tag.freelancis.net/2015/webrtconf'
     links: []

--- a/content/meetups/2015-02-26.md
+++ b/content/meetups/2015-02-26.md
@@ -15,7 +15,7 @@ talks:
     authors:
       - name: Hugo Cordier
         url: 'https://twitter.com/HugoCrd'
-        avatar: 'https://avatars.io/twitter/HugoCrd'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/HugoCrd&embed=image.url'
     slides:
       - >-
         https://speakerdeck.com/hugocrd/functional-reactive-programming-with-rxjs
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: Alexandre 'bobylito' Stanislawski
         url: 'https://twitter.com/bobylito'
-        avatar: https://avatars.io/twitter/bobylito
+        avatar: https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url
     slides:
       - 'https://speakerdeck.com/bobylito/the-promise-and-the-hack'
     links: []
@@ -48,7 +48,7 @@ talks:
     authors:
       - name: Julien 'revolunet' Bouquillon
         url: 'https://twitter.com/revolunet'
-        avatar: https://avatars.io/twitter/revolunet
+        avatar: https://api.microlink.io/?url=https://twitter.com/revolunet&embed=image.url
     slides:
       - 'http://blog.revolunet.com/angular-react-meetup/'
     links:
@@ -70,7 +70,7 @@ talks:
     authors:
       - name: Gaspard Beernaert
         url: 'https://twitter.com/freelancis'
-        avatar: 'https://avatars.io/twitter/freelancis'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/freelancis&embed=image.url'
     slides:
       - 'http://tag.freelancis.net/2015/webrtconf'
     links: []

--- a/content/meetups/2015-03-25.md
+++ b/content/meetups/2015-03-25.md
@@ -68,7 +68,7 @@ talks:
     authors:
       - name: Gabriel Majoulet
         url: 'https://twitter.com/gmajoulet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&amps;embed=image.url'
     slides:
       - 'https://www.slideshare.net/gmajoulet/paris-js-asynchronous'
     links: []
@@ -85,7 +85,7 @@ talks:
     authors:
       - name: Gaël Métais
         url: 'https://twitter.com/gaelmetais'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/gaelmetais&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gaelmetais&amps;embed=image.url'
     slides:
       - 'http://www.slideshare.net/gaelmetais/ylt-paris-js-mars-2015'
     links:

--- a/content/meetups/2015-03-25.md
+++ b/content/meetups/2015-03-25.md
@@ -68,7 +68,7 @@ talks:
     authors:
       - name: Gabriel Majoulet
         url: 'https://twitter.com/gmajoulet'
-        avatar: 'https://avatars.io/twitter/gmajoulet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gmajoulet&embed=image.url'
     slides:
       - 'https://www.slideshare.net/gmajoulet/paris-js-asynchronous'
     links: []
@@ -85,7 +85,7 @@ talks:
     authors:
       - name: Gaël Métais
         url: 'https://twitter.com/gaelmetais'
-        avatar: 'https://avatars.io/twitter/gaelmetais'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gaelmetais&embed=image.url'
     slides:
       - 'http://www.slideshare.net/gaelmetais/ylt-paris-js-mars-2015'
     links:

--- a/content/meetups/2015-04-09.md
+++ b/content/meetups/2015-04-09.md
@@ -17,7 +17,7 @@ talks:
     authors:
       - name: Thomas Crevoisier
         url: 'https://twitter.com/ThomasC__'
-        avatar: 'https://avatars.io/twitter/gaelmetais'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gaelmetais&embed=image.url'
     slides:
       - 'http://thomascrvsr.github.io/sweetjs-parisjs-45'
     links:
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: Jean-Loup Karst
         url: 'https://twitter.com/JeanloupKarst'
-        avatar: https://avatars.io/twitter/JeanloupKarst
+        avatar: https://api.microlink.io/?url=https://twitter.com/JeanloupKarst&embed=image.url
     slides: []
     links:
       - 'https://techtalent.io/'

--- a/content/meetups/2015-04-09.md
+++ b/content/meetups/2015-04-09.md
@@ -17,7 +17,7 @@ talks:
     authors:
       - name: Thomas Crevoisier
         url: 'https://twitter.com/ThomasC__'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/gaelmetais&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gaelmetais&amps;embed=image.url'
     slides:
       - 'http://thomascrvsr.github.io/sweetjs-parisjs-45'
     links:
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: Jean-Loup Karst
         url: 'https://twitter.com/JeanloupKarst'
-        avatar: https://api.microlink.io/?url=https://twitter.com/JeanloupKarst&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/JeanloupKarst&amps;embed=image.url
     slides: []
     links:
       - 'https://techtalent.io/'

--- a/content/meetups/2015-04-29.md
+++ b/content/meetups/2015-04-29.md
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Jerome Etienne
         url: 'https://twitter.com/jerome_etienne'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/jerome_etienne&amps;embed=image.url'
     slides: []
     links:
       - 'http://jsdocedjs.org/'
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: Alexandre Stanislawski
         url: 'https://twitter.com/bobylito'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&amps;embed=image.url'
     slides:
       - 'https://speakerdeck.com/bobylito/npm-run-all'
     links: []
@@ -53,7 +53,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
     slides:
       - 'https://gist.github.com/bloodyowl/060a52ef6cfef150ddd4'
     links: []
@@ -66,7 +66,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/harrisfreddy&amps;embed=image.url
     slides:
       - 'http://freddy03h.github.io/flexbox-presentation/#/'
     links: []

--- a/content/meetups/2015-04-29.md
+++ b/content/meetups/2015-04-29.md
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Jerome Etienne
         url: 'https://twitter.com/jerome_etienne'
-        avatar: 'https://avatars.io/twitter/jerome_etienne'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/jerome_etienne&embed=image.url'
     slides: []
     links:
       - 'http://jsdocedjs.org/'
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: Alexandre Stanislawski
         url: 'https://twitter.com/bobylito'
-        avatar: 'https://avatars.io/twitter/bobylito'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url'
     slides:
       - 'https://speakerdeck.com/bobylito/npm-run-all'
     links: []
@@ -53,7 +53,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://avatars.io/twitter/bloodyowl'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
     slides:
       - 'https://gist.github.com/bloodyowl/060a52ef6cfef150ddd4'
     links: []
@@ -66,7 +66,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: https://avatars.io/twitter/harrisfreddy
+        avatar: https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url
     slides:
       - 'http://freddy03h.github.io/flexbox-presentation/#/'
     links: []

--- a/content/meetups/2015-05-27.md
+++ b/content/meetups/2015-05-27.md
@@ -17,7 +17,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/Hugo_Agbonon'
-        avatar: https://avatars.io/twitter/Hugo_Agbonon
+        avatar: https://api.microlink.io/?url=https://twitter.com/Hugo_Agbonon&embed=image.url
     slides:
       - 'http://hugo-agbonon.github.io/presentations/es2015/'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: Julien Guéznet
         url: 'https://twitter.com/molokoloco'
-        avatar: https://avatars.io/twitter/molokoloco
+        avatar: https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url
     slides:
       - 'http://slides.com/molokoloco/jquery/'
     links: []
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: Pierrick Paul
         url: 'https://twitter.com/le_mulot'
-        avatar: https://avatars.io/twitter/le_mulot
+        avatar: https://api.microlink.io/?url=https://twitter.com/le_mulot&embed=image.url
     slides:
       - >-
         https://docs.google.com/presentation/d/1tjNctxo-Uh8kfBYAKm8uHHN5vX8X2PTca2eGvfSB6vo/edit#slide=id.p
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: François Zaninotto
         url: 'https://twitter.com/francoisz'
-        avatar: https://avatars.io/twitter/francoisz
+        avatar: https://api.microlink.io/?url=https://twitter.com/francoisz&embed=image.url
     slides: []
     links:
       - 'https://github.com/marmelab/ng-admin'

--- a/content/meetups/2015-05-27.md
+++ b/content/meetups/2015-05-27.md
@@ -17,7 +17,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/Hugo_Agbonon'
-        avatar: https://api.microlink.io/?url=https://twitter.com/Hugo_Agbonon&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/Hugo_Agbonon&amps;embed=image.url
     slides:
       - 'http://hugo-agbonon.github.io/presentations/es2015/'
     links: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: Julien Guéznet
         url: 'https://twitter.com/molokoloco'
-        avatar: https://api.microlink.io/?url=https://twitter.com/molokoloco&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/molokoloco&amps;embed=image.url
     slides:
       - 'http://slides.com/molokoloco/jquery/'
     links: []
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: Pierrick Paul
         url: 'https://twitter.com/le_mulot'
-        avatar: https://api.microlink.io/?url=https://twitter.com/le_mulot&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/le_mulot&amps;embed=image.url
     slides:
       - >-
         https://docs.google.com/presentation/d/1tjNctxo-Uh8kfBYAKm8uHHN5vX8X2PTca2eGvfSB6vo/edit#slide=id.p
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: François Zaninotto
         url: 'https://twitter.com/francoisz'
-        avatar: https://api.microlink.io/?url=https://twitter.com/francoisz&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/francoisz&amps;embed=image.url
     slides: []
     links:
       - 'https://github.com/marmelab/ng-admin'

--- a/content/meetups/2015-06-24.md
+++ b/content/meetups/2015-06-24.md
@@ -12,7 +12,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
     slides:
       - 'http://bloodyowl.github.io/talk-css-at-scale/'
     links: []
@@ -28,7 +28,7 @@ talks:
     authors:
       - name: Jean Dupouy
         url: 'https://twitter.com/Izeau'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Izeau&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Izeau&amps;embed=image.url'
     slides: []
     links:
       - 'https://github.com/izeau/ng-build'
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: Elalami Lafkih
         url: 'https://twitter.com/e_lalami'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/e_lalami&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/e_lalami&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -80,7 +80,7 @@ talks:
     authors:
       - name: Nicolas Babel
         url: 'https://twitter.com/nicbaboul'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/nicbaboul&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nicbaboul&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2015-06-24.md
+++ b/content/meetups/2015-06-24.md
@@ -12,7 +12,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://avatars.io/twitter/bloodyowl'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
     slides:
       - 'http://bloodyowl.github.io/talk-css-at-scale/'
     links: []
@@ -28,7 +28,7 @@ talks:
     authors:
       - name: Jean Dupouy
         url: 'https://twitter.com/Izeau'
-        avatar: 'https://avatars.io/twitter/Izeau'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Izeau&embed=image.url'
     slides: []
     links:
       - 'https://github.com/izeau/ng-build'
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: Elalami Lafkih
         url: 'https://twitter.com/e_lalami'
-        avatar: 'https://avatars.io/twitter/e_lalami'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/e_lalami&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -80,7 +80,7 @@ talks:
     authors:
       - name: Nicolas Babel
         url: 'https://twitter.com/nicbaboul'
-        avatar: 'https://avatars.io/twitter/nicbaboul'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nicbaboul&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2015-09-30.md
+++ b/content/meetups/2015-09-30.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: Wassim Chegham
         url: 'https://twitter.com/manekinekko'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&amps;embed=image.url'
     slides:
       - 'http://slides.com/wassimchegham/angular-universal'
     links:
@@ -58,7 +58,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/hugo_agbonon'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/hugo_agbonon&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/hugo_agbonon&amps;embed=image.url'
     slides:
       - 'http://hugo-agbonon.github.io/presentations/nodev4'
     links:
@@ -72,7 +72,7 @@ talks:
     authors:
       - name: Wassim Chegham
         url: 'https://twitter.com/manekinekko'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&amps;embed=image.url'
     slides:
       - 'http://slides.com/wassimchegham/yo-generator'
     links:

--- a/content/meetups/2015-09-30.md
+++ b/content/meetups/2015-09-30.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: Wassim Chegham
         url: 'https://twitter.com/manekinekko'
-        avatar: 'https://avatars.io/twitter/manekinekko'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&embed=image.url'
     slides:
       - 'http://slides.com/wassimchegham/angular-universal'
     links:
@@ -58,7 +58,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/hugo_agbonon'
-        avatar: 'https://avatars.io/twitter/hugo_agbonon'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/hugo_agbonon&embed=image.url'
     slides:
       - 'http://hugo-agbonon.github.io/presentations/nodev4'
     links:
@@ -72,7 +72,7 @@ talks:
     authors:
       - name: Wassim Chegham
         url: 'https://twitter.com/manekinekko'
-        avatar: 'https://avatars.io/twitter/manekinekko'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&embed=image.url'
     slides:
       - 'http://slides.com/wassimchegham/yo-generator'
     links:

--- a/content/meetups/2015-10-28.md
+++ b/content/meetups/2015-10-28.md
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://avatars.io/twitter/harrisfreddy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
     slides:
       - 'http://freddy03h.github.io/render-presentation/#/'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: Valentin Waeselynck
         url: 'https://twitter.com/val_waeselynck'
-        avatar: 'https://avatars.io/twitter/val_waeselynck'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/val_waeselynck&embed=image.url'
     slides:
       - 'http://slides.com/valwaeselynck/clojurescript-parisjs#/'
     links:
@@ -60,7 +60,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/codeheroics'
-        avatar: 'https://avatars.io/twitter/codeheroics'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&embed=image.url'
     slides:
       - 'http://hugo-agbonon.github.io/presentations/npm3/index.html'
     links:
@@ -80,7 +80,7 @@ talks:
     authors:
       - name: Alejandro Mantecon Guillen
         url: 'https://twitter.com/alemangui'
-        avatar: 'https://avatars.io/twitter/alemangui'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alemangui&embed=image.url'
     slides:
       - 'https://alemangui.github.io/Paris-JS-meetup.pdf'
     links:

--- a/content/meetups/2015-10-28.md
+++ b/content/meetups/2015-10-28.md
@@ -22,7 +22,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&amps;embed=image.url'
     slides:
       - 'http://freddy03h.github.io/render-presentation/#/'
     links: []
@@ -44,7 +44,7 @@ talks:
     authors:
       - name: Valentin Waeselynck
         url: 'https://twitter.com/val_waeselynck'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/val_waeselynck&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/val_waeselynck&amps;embed=image.url'
     slides:
       - 'http://slides.com/valwaeselynck/clojurescript-parisjs#/'
     links:
@@ -60,7 +60,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/codeheroics'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&amps;embed=image.url'
     slides:
       - 'http://hugo-agbonon.github.io/presentations/npm3/index.html'
     links:
@@ -80,7 +80,7 @@ talks:
     authors:
       - name: Alejandro Mantecon Guillen
         url: 'https://twitter.com/alemangui'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/alemangui&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alemangui&amps;embed=image.url'
     slides:
       - 'https://alemangui.github.io/Paris-JS-meetup.pdf'
     links:

--- a/content/meetups/2015-11-25.md
+++ b/content/meetups/2015-11-25.md
@@ -27,7 +27,7 @@ talks:
     authors:
       - name: Gaëtan Renaudeau
         url: 'https://twitter.com/greweb'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/greweb&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/greweb&amps;embed=image.url'
     slides:
       - 'http://greweb.me/parisjs51'
     links:
@@ -70,7 +70,7 @@ talks:
     authors:
       - name: Szymon Kaliski
         url: 'https://twitter.com/szymon_k'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/szymon_k&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/szymon_k&amps;embed=image.url'
     slides:
       - 'http://promo.treesmovethemost.com/slides/2015-11-25-parisjs.pdf'
     links:
@@ -88,7 +88,7 @@ talks:
     authors:
       - name: Emmanuel Remy
         url: 'https://twitter.com/manuremy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&amps;embed=image.url'
     slides:
       - 'https://drive.google.com/file/d/0B9-b_ykG-y2ZSEJOMllDNVFGbW8/view'
     links:

--- a/content/meetups/2015-11-25.md
+++ b/content/meetups/2015-11-25.md
@@ -27,7 +27,7 @@ talks:
     authors:
       - name: Gaëtan Renaudeau
         url: 'https://twitter.com/greweb'
-        avatar: 'https://avatars.io/twitter/greweb'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/greweb&embed=image.url'
     slides:
       - 'http://greweb.me/parisjs51'
     links:
@@ -70,7 +70,7 @@ talks:
     authors:
       - name: Szymon Kaliski
         url: 'https://twitter.com/szymon_k'
-        avatar: 'https://avatars.io/twitter/szymon_k'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/szymon_k&embed=image.url'
     slides:
       - 'http://promo.treesmovethemost.com/slides/2015-11-25-parisjs.pdf'
     links:
@@ -88,7 +88,7 @@ talks:
     authors:
       - name: Emmanuel Remy
         url: 'https://twitter.com/manuremy'
-        avatar: 'https://avatars.io/twitter/manuremy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
     slides:
       - 'https://drive.google.com/file/d/0B9-b_ykG-y2ZSEJOMllDNVFGbW8/view'
     links:

--- a/content/meetups/2016-01-27.md
+++ b/content/meetups/2016-01-27.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: Jérémie Drouet
         url: 'https://twitter.com/jeremiedrouet'
-        avatar: 'https://avatars.io/twitter/jeremiedrouet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/jeremiedrouet&embed=image.url'
     slides:
       - 'http://slides.com/jeremiedrouet/loopback-satellizer#/'
     links:
@@ -41,7 +41,7 @@ talks:
     authors:
       - name: Christophe Rosset
         url: 'https://twitter.com/topheman'
-        avatar: 'https://avatars.io/twitter/topheman'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&embed=image.url'
     slides:
       - 'https://topheman.github.io/talks/react-es6-redux/'
     links:
@@ -54,7 +54,7 @@ talks:
     authors:
       - name: Jonathan Petitcolas
         url: 'https://twitter.com/Sethpolma'
-        avatar: 'https://avatars.io/twitter/Sethpolma'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Sethpolma&embed=image.url'
     slides:
       - >-
         http://www.jonathan-petitcolas.com/talks/2015-12-16-zombo-reloaded-introduction-to-webpack.html

--- a/content/meetups/2016-01-27.md
+++ b/content/meetups/2016-01-27.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: Jérémie Drouet
         url: 'https://twitter.com/jeremiedrouet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/jeremiedrouet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/jeremiedrouet&amps;embed=image.url'
     slides:
       - 'http://slides.com/jeremiedrouet/loopback-satellizer#/'
     links:
@@ -41,7 +41,7 @@ talks:
     authors:
       - name: Christophe Rosset
         url: 'https://twitter.com/topheman'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&amps;embed=image.url'
     slides:
       - 'https://topheman.github.io/talks/react-es6-redux/'
     links:
@@ -54,7 +54,7 @@ talks:
     authors:
       - name: Jonathan Petitcolas
         url: 'https://twitter.com/Sethpolma'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Sethpolma&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Sethpolma&amps;embed=image.url'
     slides:
       - >-
         http://www.jonathan-petitcolas.com/talks/2015-12-16-zombo-reloaded-introduction-to-webpack.html

--- a/content/meetups/2016-02-24.md
+++ b/content/meetups/2016-02-24.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Mathieu Parisot
         url: 'https://twitter.com/matparisot'
-        avatar: 'https://avatars.io/twitter/matparisot'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/matparisot&embed=image.url'
     slides:
       - >-
         http://fr.slideshare.net/matparisot/css-grid-layout-le-futur-de-vos-mises-en-page
@@ -43,7 +43,7 @@ talks:
     authors:
       - name: Alexis Janvier
         url: 'https://twitter.com/alexisjanvier'
-        avatar: 'https://avatars.io/twitter/alexisjanvier'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alexisjanvier&embed=image.url'
     slides:
       - 'http://slides.com/alexisjanvier-1/manage-dev-test-servers-with-pm2#/'
     links:
@@ -57,7 +57,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/codeheroics'
-        avatar: 'https://avatars.io/twitter/codeheroics'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&embed=image.url'
     slides:
       - 'http://codeheroics.github.io/talks/es2016-plus/'
     links:

--- a/content/meetups/2016-02-24.md
+++ b/content/meetups/2016-02-24.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Mathieu Parisot
         url: 'https://twitter.com/matparisot'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/matparisot&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/matparisot&amps;embed=image.url'
     slides:
       - >-
         http://fr.slideshare.net/matparisot/css-grid-layout-le-futur-de-vos-mises-en-page
@@ -43,7 +43,7 @@ talks:
     authors:
       - name: Alexis Janvier
         url: 'https://twitter.com/alexisjanvier'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/alexisjanvier&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alexisjanvier&amps;embed=image.url'
     slides:
       - 'http://slides.com/alexisjanvier-1/manage-dev-test-servers-with-pm2#/'
     links:
@@ -57,7 +57,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/codeheroics'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&amps;embed=image.url'
     slides:
       - 'http://codeheroics.github.io/talks/es2016-plus/'
     links:

--- a/content/meetups/2016-03-30.md
+++ b/content/meetups/2016-03-30.md
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: Florian Rival
         url: 'https://twitter.com/Florianrival'
-        avatar: 'https://avatars.io/twitter/Florianrival'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&embed=image.url'
     slides: []
     links:
       - 'http://emscripten.org'
@@ -49,7 +49,7 @@ talks:
     authors:
       - name: Erik Escoffier
         url: 'https://twitter.com/nerik'
-        avatar: 'https://avatars.io/twitter/nerik'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nerik&embed=image.url'
     slides:
       - >-
         https://docs.google.com/presentation/d/1XfL0PiVxjm-9C8D1nc1ICKCPhs139-bzg-QyYi4y0CI/edit?usp=sharing
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: Woody Rousseau
         url: 'https://twitter.com/WoodyRousseau'
-        avatar: 'https://avatars.io/twitter/WoodyRousseau'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/WoodyRousseau&embed=image.url'
     slides: []
     links:
       - 'https://github.com/wrousseau/angular-defensive'

--- a/content/meetups/2016-03-30.md
+++ b/content/meetups/2016-03-30.md
@@ -24,7 +24,7 @@ talks:
     authors:
       - name: Florian Rival
         url: 'https://twitter.com/Florianrival'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&amps;embed=image.url'
     slides: []
     links:
       - 'http://emscripten.org'
@@ -49,7 +49,7 @@ talks:
     authors:
       - name: Erik Escoffier
         url: 'https://twitter.com/nerik'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/nerik&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nerik&amps;embed=image.url'
     slides:
       - >-
         https://docs.google.com/presentation/d/1XfL0PiVxjm-9C8D1nc1ICKCPhs139-bzg-QyYi4y0CI/edit?usp=sharing
@@ -69,7 +69,7 @@ talks:
     authors:
       - name: Woody Rousseau
         url: 'https://twitter.com/WoodyRousseau'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/WoodyRousseau&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/WoodyRousseau&amps;embed=image.url'
     slides: []
     links:
       - 'https://github.com/wrousseau/angular-defensive'

--- a/content/meetups/2016-04-27.md
+++ b/content/meetups/2016-04-27.md
@@ -20,7 +20,7 @@ talks:
     authors:
       - name: Benjamin Winckell
         url: 'https://twitter.com/oh_meeen'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/oh_meeen&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/oh_meeen&amps;embed=image.url'
     slides:
       - 'http://slides.com/ben080989/deck/fullscreen#/'
     links:
@@ -66,7 +66,7 @@ talks:
     authors:
       - name: Tim Carry
         url: 'https://twitter.com/pixelastic'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/pixelastic&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/pixelastic&amps;embed=image.url'
     slides:
       - 'http://talks.pixelastic.com/marvel-parisjs/#/'
     links:
@@ -82,7 +82,7 @@ talks:
     authors:
       - name: Wassim Chegham
         url: 'https://twitter.com/manekinekko'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&amps;embed=image.url'
     slides:
       - 'http://slides.com/wassimchegham/introducing-angular-2-in-20-minutes#/'
     links:
@@ -104,7 +104,7 @@ talks:
     authors:
       - name: Nicolas Goutay
         url: 'https://twitter.com/Phacks'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Phacks&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Phacks&amps;embed=image.url'
     slides:
       - 'http://fr.slideshare.net/NicolasGoutay/paris-js'
     links:

--- a/content/meetups/2016-04-27.md
+++ b/content/meetups/2016-04-27.md
@@ -20,7 +20,7 @@ talks:
     authors:
       - name: Benjamin Winckell
         url: 'https://twitter.com/oh_meeen'
-        avatar: 'https://avatars.io/twitter/oh_meeen'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/oh_meeen&embed=image.url'
     slides:
       - 'http://slides.com/ben080989/deck/fullscreen#/'
     links:
@@ -66,7 +66,7 @@ talks:
     authors:
       - name: Tim Carry
         url: 'https://twitter.com/pixelastic'
-        avatar: 'https://avatars.io/twitter/pixelastic'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/pixelastic&embed=image.url'
     slides:
       - 'http://talks.pixelastic.com/marvel-parisjs/#/'
     links:
@@ -82,7 +82,7 @@ talks:
     authors:
       - name: Wassim Chegham
         url: 'https://twitter.com/manekinekko'
-        avatar: 'https://avatars.io/twitter/manekinekko'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manekinekko&embed=image.url'
     slides:
       - 'http://slides.com/wassimchegham/introducing-angular-2-in-20-minutes#/'
     links:
@@ -104,7 +104,7 @@ talks:
     authors:
       - name: Nicolas Goutay
         url: 'https://twitter.com/Phacks'
-        avatar: 'https://avatars.io/twitter/Phacks'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Phacks&embed=image.url'
     slides:
       - 'http://fr.slideshare.net/NicolasGoutay/paris-js'
     links:

--- a/content/meetups/2016-05-25.md
+++ b/content/meetups/2016-05-25.md
@@ -27,7 +27,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://avatars.io/twitter/harrisfreddy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
     slides:
       - 'http://freddy03h.github.io/flip-presentation/'
     links: []
@@ -41,7 +41,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://avatars.io/twitter/bloodyowl'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
     slides:
       - >-
         https://speakerdeck.com/bloodyowl/flow-du-strong-static-typing-pour-javascript
@@ -56,7 +56,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/codeheroics'
-        avatar: 'https://avatars.io/twitter/codeheroics'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&embed=image.url'
     slides:
       - 'http://codeheroics.github.io/talks/nodemjs/index.html'
     links:
@@ -76,7 +76,7 @@ talks:
     authors:
       - name: Alejandro Mantecon Guillen
         url: 'https://twitter.com/alemangui'
-        avatar: 'https://avatars.io/twitter/alemangui'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alemangui&embed=image.url'
     slides:
       - 'https://alemangui.github.io/meetups/Pizzicato.compressed.pdf'
     links:

--- a/content/meetups/2016-05-25.md
+++ b/content/meetups/2016-05-25.md
@@ -27,7 +27,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&amps;embed=image.url'
     slides:
       - 'http://freddy03h.github.io/flip-presentation/'
     links: []
@@ -41,7 +41,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
     slides:
       - >-
         https://speakerdeck.com/bloodyowl/flow-du-strong-static-typing-pour-javascript
@@ -56,7 +56,7 @@ talks:
     authors:
       - name: Hugo Agbonon
         url: 'https://twitter.com/codeheroics'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/codeheroics&amps;embed=image.url'
     slides:
       - 'http://codeheroics.github.io/talks/nodemjs/index.html'
     links:
@@ -76,7 +76,7 @@ talks:
     authors:
       - name: Alejandro Mantecon Guillen
         url: 'https://twitter.com/alemangui'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/alemangui&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alemangui&amps;embed=image.url'
     slides:
       - 'https://alemangui.github.io/meetups/Pizzicato.compressed.pdf'
     links:

--- a/content/meetups/2016-06-29.md
+++ b/content/meetups/2016-06-29.md
@@ -17,7 +17,7 @@ talks:
     authors:
       - name: Eric Horesnyi
         url: 'https://twitter.com/EricHoresnyi'
-        avatar: 'https://avatars.io/twitter/EricHoresnyi'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/EricHoresnyi&embed=image.url'
     slides:
       - >-
         http://www.slideshare.net/community_streamdataIO/haussmann-fielding-fowler-networkbased-architects
@@ -43,7 +43,7 @@ talks:
     authors:
       - name: Guillaume Claret
         url: 'https://twitter.com/guillau82874703'
-        avatar: 'https://avatars.io/twitter/guillau82874703'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/guillau82874703&embed=image.url'
     slides:
       - 'http://ouicar.github.io/assets/slides/meetup-elm-js/#/'
     links: []
@@ -62,7 +62,7 @@ talks:
     authors:
       - name: Nicolas Carlo
         url: 'https://twitter.com/nicoespeon'
-        avatar: 'https://avatars.io/twitter/nicoespeon'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nicoespeon&embed=image.url'
     slides:
       - >-
         https://medium.com/@nicoespeon/talk-fr-trello-kanban-cycle-js-1c394b205c6e#.xnlysplex

--- a/content/meetups/2016-06-29.md
+++ b/content/meetups/2016-06-29.md
@@ -17,7 +17,7 @@ talks:
     authors:
       - name: Eric Horesnyi
         url: 'https://twitter.com/EricHoresnyi'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/EricHoresnyi&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/EricHoresnyi&amps;embed=image.url'
     slides:
       - >-
         http://www.slideshare.net/community_streamdataIO/haussmann-fielding-fowler-networkbased-architects
@@ -43,7 +43,7 @@ talks:
     authors:
       - name: Guillaume Claret
         url: 'https://twitter.com/guillau82874703'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/guillau82874703&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/guillau82874703&amps;embed=image.url'
     slides:
       - 'http://ouicar.github.io/assets/slides/meetup-elm-js/#/'
     links: []
@@ -62,7 +62,7 @@ talks:
     authors:
       - name: Nicolas Carlo
         url: 'https://twitter.com/nicoespeon'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/nicoespeon&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nicoespeon&amps;embed=image.url'
     slides:
       - >-
         https://medium.com/@nicoespeon/talk-fr-trello-kanban-cycle-js-1c394b205c6e#.xnlysplex

--- a/content/meetups/2016-10-05.md
+++ b/content/meetups/2016-10-05.md
@@ -30,7 +30,7 @@ talks:
     authors:
       - name: Florian Rival
         url: 'https://twitter.com/Florianrival'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&amps;embed=image.url'
     slides:
       - 'http://slides.com/florianrival/javascript-games#/'
     links: []
@@ -59,7 +59,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/HarrisFreddy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/HarrisFreddy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/HarrisFreddy&amps;embed=image.url'
     slides:
       - 'https://freddy03h.github.io/react-animations-presentation/'
     links: []

--- a/content/meetups/2016-10-05.md
+++ b/content/meetups/2016-10-05.md
@@ -30,7 +30,7 @@ talks:
     authors:
       - name: Florian Rival
         url: 'https://twitter.com/Florianrival'
-        avatar: 'https://avatars.io/twitter/Florianrival'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&embed=image.url'
     slides:
       - 'http://slides.com/florianrival/javascript-games#/'
     links: []
@@ -59,7 +59,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/HarrisFreddy'
-        avatar: 'https://avatars.io/twitter/HarrisFreddy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/HarrisFreddy&embed=image.url'
     slides:
       - 'https://freddy03h.github.io/react-animations-presentation/'
     links: []

--- a/content/meetups/2016-10-26.md
+++ b/content/meetups/2016-10-26.md
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: Olivier Tassinari
         url: 'https://twitter.com/olivtassinari'
-        avatar: 'https://avatars.io/twitter/olivtassinari'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/olivtassinari&embed=image.url'
     slides:
       - 'https://github.com/oliviertassinari/a-journey-toward-better-style'
     links: []
@@ -63,7 +63,7 @@ talks:
     authors:
       - name: Jonathan Jalouzot
         url: 'https://twitter.com/CaptainJojo42'
-        avatar: 'https://avatars.io/twitter/CaptainJojo42'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/CaptainJojo42&embed=image.url'
     slides:
       - 'http://blog.eleven-labs.com/fr/votre-premiere-pwa/'
     links: []
@@ -86,7 +86,7 @@ talks:
     authors:
       - name: Thibaut Cheymol
         url: 'https://twitter.com/thibaut_cheymol'
-        avatar: 'https://avatars.io/twitter/thibaut_cheymol'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/thibaut_cheymol&embed=image.url'
     slides:
       - 'https://blog.bam.tech/developper-news/react-jest-snapshots'
     links:
@@ -109,7 +109,7 @@ talks:
     authors:
       - name: Emmanuel Remy
         url: 'https://twitter.com/manuremy'
-        avatar: 'https://avatars.io/twitter/manuremy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2016-10-26.md
+++ b/content/meetups/2016-10-26.md
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: Olivier Tassinari
         url: 'https://twitter.com/olivtassinari'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/olivtassinari&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/olivtassinari&amps;embed=image.url'
     slides:
       - 'https://github.com/oliviertassinari/a-journey-toward-better-style'
     links: []
@@ -63,7 +63,7 @@ talks:
     authors:
       - name: Jonathan Jalouzot
         url: 'https://twitter.com/CaptainJojo42'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/CaptainJojo42&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/CaptainJojo42&amps;embed=image.url'
     slides:
       - 'http://blog.eleven-labs.com/fr/votre-premiere-pwa/'
     links: []
@@ -86,7 +86,7 @@ talks:
     authors:
       - name: Thibaut Cheymol
         url: 'https://twitter.com/thibaut_cheymol'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/thibaut_cheymol&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/thibaut_cheymol&amps;embed=image.url'
     slides:
       - 'https://blog.bam.tech/developper-news/react-jest-snapshots'
     links:
@@ -109,7 +109,7 @@ talks:
     authors:
       - name: Emmanuel Remy
         url: 'https://twitter.com/manuremy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/manuremy&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2016-12-03.md
+++ b/content/meetups/2016-12-03.md
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Tim Carry
         url: 'https://twitter.com/pixelastic'
-        avatar: 'https://avatars.io/twitter/pixelastic'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/pixelastic&embed=image.url'
     slides:
       - 'http://www.slidedeck.io/pixelastic/talk-docsearch'
     links: []
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: Xavier Durand
         url: 'https://twitter.com/xavedurand'
-        avatar: 'https://avatars.io/twitter/xavedurand'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/xavedurand&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -54,7 +54,7 @@ talks:
     authors:
       - name: Stefan Judis
         url: 'https://twitter.com/stefanjudis'
-        avatar: 'https://avatars.io/twitter/stefanjudis'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/stefanjudis&embed=image.url'
     slides:
       - >-
         https://speakerdeck.com/stefanjudis/unicode-javascript-and-the-emoji-family
@@ -73,7 +73,7 @@ talks:
     authors:
       - name: Nicolas Boutin
         url: 'https://twitter.com/BoutinNico'
-        avatar: 'https://avatars.io/twitter/BoutinNico'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/BoutinNico&embed=image.url'
     slides:
       - >-
         https://docs.google.com/presentation/d/1mEOVaGxXhI-76yEoxo27nsFwdLlSNledGHtYc4eVUUo/edit#slide=id.g19e2d9ed18_0_167
@@ -92,7 +92,7 @@ talks:
     authors:
       - name: Tessa Mero
         url: 'https://twitter.com/TessaMero'
-        avatar: 'https://avatars.io/twitter/TessaMero'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/TessaMero&embed=image.url'
     slides:
       - >-
         http://fr.slideshare.net/Tessa99/understanding-rest-apis-in-5-simple-steps-69937208
@@ -105,7 +105,7 @@ talks:
     authors:
       - name: Thibaut Cheymol
         url: 'https://twitter.com/thibaut_cheymol'
-        avatar: 'https://avatars.io/twitter/thibaut_cheymol'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/thibaut_cheymol&embed=image.url'
     slides:
       - 'https://blog.bam.tech/developper-news/yarn'
     links: []

--- a/content/meetups/2016-12-03.md
+++ b/content/meetups/2016-12-03.md
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Tim Carry
         url: 'https://twitter.com/pixelastic'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/pixelastic&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/pixelastic&amps;embed=image.url'
     slides:
       - 'http://www.slidedeck.io/pixelastic/talk-docsearch'
     links: []
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: Xavier Durand
         url: 'https://twitter.com/xavedurand'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/xavedurand&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/xavedurand&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -54,7 +54,7 @@ talks:
     authors:
       - name: Stefan Judis
         url: 'https://twitter.com/stefanjudis'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/stefanjudis&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/stefanjudis&amps;embed=image.url'
     slides:
       - >-
         https://speakerdeck.com/stefanjudis/unicode-javascript-and-the-emoji-family
@@ -73,7 +73,7 @@ talks:
     authors:
       - name: Nicolas Boutin
         url: 'https://twitter.com/BoutinNico'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/BoutinNico&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/BoutinNico&amps;embed=image.url'
     slides:
       - >-
         https://docs.google.com/presentation/d/1mEOVaGxXhI-76yEoxo27nsFwdLlSNledGHtYc4eVUUo/edit#slide=id.g19e2d9ed18_0_167
@@ -92,7 +92,7 @@ talks:
     authors:
       - name: Tessa Mero
         url: 'https://twitter.com/TessaMero'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/TessaMero&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/TessaMero&amps;embed=image.url'
     slides:
       - >-
         http://fr.slideshare.net/Tessa99/understanding-rest-apis-in-5-simple-steps-69937208
@@ -105,7 +105,7 @@ talks:
     authors:
       - name: Thibaut Cheymol
         url: 'https://twitter.com/thibaut_cheymol'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/thibaut_cheymol&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/thibaut_cheymol&amps;embed=image.url'
     slides:
       - 'https://blog.bam.tech/developper-news/yarn'
     links: []

--- a/content/meetups/2017-01-25.md
+++ b/content/meetups/2017-01-25.md
@@ -14,7 +14,7 @@ talks:
     authors:
       - name: Maël Nison
         url: 'https://twitter.com/arcanis'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&amps;embed=image.url'
     slides:
       - >-
         https://docs.google.com/presentation/d/1NswmLxESHnw9IF5ypSdm3Hx0Hexn-2uKP6jGV2tb6Ac/edit?usp=sharing
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Jacopo Daeli
         url: 'https://twitter.com/JacopoDaeli'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&amps;embed=image.url'
     slides:
       - >-
         https://speakerdeck.com/jacopodaeli/paris-dot-js-real-time-apps-with-graphql-node-dot-js-and-mqtt
@@ -60,7 +60,7 @@ talks:
     authors:
       - name: Jean-loup Karst
         url: 'https://twitter.com/JeanloupKarst'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/JeanloupKarst&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JeanloupKarst&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -95,7 +95,7 @@ talks:
     authors:
       - name: Florian Rival
         url: 'https://twitter.com/Florianrival'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&amps;embed=image.url'
     slides:
       - 'http://slides.com/florianrival/dynamic-apps-react-redux#/'
     links: []

--- a/content/meetups/2017-01-25.md
+++ b/content/meetups/2017-01-25.md
@@ -14,7 +14,7 @@ talks:
     authors:
       - name: Maël Nison
         url: 'https://twitter.com/arcanis'
-        avatar: 'https://avatars.io/twitter/arcanis'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&embed=image.url'
     slides:
       - >-
         https://docs.google.com/presentation/d/1NswmLxESHnw9IF5ypSdm3Hx0Hexn-2uKP6jGV2tb6Ac/edit?usp=sharing
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Jacopo Daeli
         url: 'https://twitter.com/JacopoDaeli'
-        avatar: 'https://avatars.io/twitter/JacopoDaeli'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&embed=image.url'
     slides:
       - >-
         https://speakerdeck.com/jacopodaeli/paris-dot-js-real-time-apps-with-graphql-node-dot-js-and-mqtt
@@ -60,7 +60,7 @@ talks:
     authors:
       - name: Jean-loup Karst
         url: 'https://twitter.com/JeanloupKarst'
-        avatar: 'https://avatars.io/twitter/JeanloupKarst'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JeanloupKarst&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -95,7 +95,7 @@ talks:
     authors:
       - name: Florian Rival
         url: 'https://twitter.com/Florianrival'
-        avatar: 'https://avatars.io/twitter/Florianrival'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Florianrival&embed=image.url'
     slides:
       - 'http://slides.com/florianrival/dynamic-apps-react-redux#/'
     links: []

--- a/content/meetups/2017-02-22.md
+++ b/content/meetups/2017-02-22.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Matthias
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://avatars.io/twitter/bloodyowl'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -21,7 +21,7 @@ talks:
     authors:
       - name: Jonathan
         url: 'https://twitter.com/Sethpolma'
-        avatar: 'https://avatars.io/twitter/Sethpolma'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Sethpolma&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Fabien
         url: 'https://twitter.com/fabienv'
-        avatar: 'https://avatars.io/twitter/fabienv'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/fabienv&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -41,7 +41,7 @@ talks:
     authors:
       - name: David
         url: 'https://twitter.com/davinov'
-        avatar: 'https://avatars.io/twitter/davinov'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/davinov&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-02-22.md
+++ b/content/meetups/2017-02-22.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Matthias
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -21,7 +21,7 @@ talks:
     authors:
       - name: Jonathan
         url: 'https://twitter.com/Sethpolma'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Sethpolma&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Sethpolma&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Fabien
         url: 'https://twitter.com/fabienv'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/fabienv&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/fabienv&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -41,7 +41,7 @@ talks:
     authors:
       - name: David
         url: 'https://twitter.com/davinov'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/davinov&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/davinov&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-03-29.md
+++ b/content/meetups/2017-03-29.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: François
         url: 'https://twitter.com/francoisz'
-        avatar: 'https://avatars.io/twitter/francoisz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francoisz&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: Mathieu
         url: null
-        avatar: 'https://avatars.io/twitter/mathrobin'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/mathrobin&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-03-29.md
+++ b/content/meetups/2017-03-29.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: François
         url: 'https://twitter.com/francoisz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/francoisz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/francoisz&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: Mathieu
         url: null
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/mathrobin&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/mathrobin&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-04-26.md
+++ b/content/meetups/2017-04-26.md
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Vladimir
         url: null
-        avatar: https://avatars.io/twitter/poledesfetes
+        avatar: https://api.microlink.io/?url=https://twitter.com/poledesfetes&embed=image.url
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-04-26.md
+++ b/content/meetups/2017-04-26.md
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Vladimir
         url: null
-        avatar: https://api.microlink.io/?url=https://twitter.com/poledesfetes&embed=image.url
+        avatar: https://api.microlink.io/?url=https://twitter.com/poledesfetes&amps;embed=image.url
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-06-28.md
+++ b/content/meetups/2017-06-28.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Haroen
         url: 'https://twitter.com/haroenv'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Romain
         url: 'https://twitter.com/Romain_Soufflet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Romain_Soufflet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Romain_Soufflet&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: Sébastien
         url: 'https://twitter.com/Durnan'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Durnan&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Durnan&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: Alexis
         url: 'https://twitter.com/alexisjanvier'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/alexisjanvier&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alexisjanvier&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-06-28.md
+++ b/content/meetups/2017-06-28.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Haroen
         url: 'https://twitter.com/haroenv'
-        avatar: 'https://avatars.io/twitter/haroenv'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Romain
         url: 'https://twitter.com/Romain_Soufflet'
-        avatar: 'https://avatars.io/twitter/Romain_Soufflet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Romain_Soufflet&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -33,7 +33,7 @@ talks:
     authors:
       - name: Sébastien
         url: 'https://twitter.com/Durnan'
-        avatar: 'https://avatars.io/twitter/Durnan'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Durnan&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: Alexis
         url: 'https://twitter.com/alexisjanvier'
-        avatar: 'https://avatars.io/twitter/alexisjanvier'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alexisjanvier&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-09-27.md
+++ b/content/meetups/2017-09-27.md
@@ -18,7 +18,7 @@ talks:
     authors:
       - name: Vincent
         url: 'https://twitter.com/Vince_Vallet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -29,7 +29,7 @@ talks:
     authors:
       - name: Mattias
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-09-27.md
+++ b/content/meetups/2017-09-27.md
@@ -18,7 +18,7 @@ talks:
     authors:
       - name: Vincent
         url: 'https://twitter.com/Vince_Vallet'
-        avatar: 'https://avatars.io/twitter/Vince_Vallet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -29,7 +29,7 @@ talks:
     authors:
       - name: Mattias
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://avatars.io/twitter/bloodyowl'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
     slides: []
     links: []
     videos: []

--- a/content/meetups/2017-10-25.md
+++ b/content/meetups/2017-10-25.md
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: Marc Loyat
         url: 'https://twitter.com/mloyat'
-        avatar: 'https://avatars.io/twitter/mloyat'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/mloyat&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2017-10-25.md
+++ b/content/meetups/2017-10-25.md
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: Marc Loyat
         url: 'https://twitter.com/mloyat'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/mloyat&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/mloyat&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2017-11-29.md
+++ b/content/meetups/2017-11-29.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: Marco Otte-Witte
         url: 'https://twitter.com/marcoow'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/marcoow&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/marcoow&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Alexander Ottenhoff
         url: 'https://twitter.com/AlexOttenhoff'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/AlexOttenhoff&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/AlexOttenhoff&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -35,7 +35,7 @@ talks:
     authors:
       - name: Dominik Kundel
         url: 'https://twitter.com/dkundel'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/dkundel&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/dkundel&amps;embed=image.url'
     slides:
       - 'https://speakerdeck.com/dkundel/code-dot-talks-2017-coffee-dot-js-how-i-hacked-my-coffee-machine-using-javascript'
     links: []

--- a/content/meetups/2017-11-29.md
+++ b/content/meetups/2017-11-29.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: Marco Otte-Witte
         url: 'https://twitter.com/marcoow'
-        avatar: 'https://avatars.io/twitter/marcoow'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/marcoow&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: Alexander Ottenhoff
         url: 'https://twitter.com/AlexOttenhoff'
-        avatar: 'https://avatars.io/twitter/AlexOttenhoff'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/AlexOttenhoff&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -35,7 +35,7 @@ talks:
     authors:
       - name: Dominik Kundel
         url: 'https://twitter.com/dkundel'
-        avatar: 'https://avatars.io/twitter/dkundel'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/dkundel&embed=image.url'
     slides:
       - 'https://speakerdeck.com/dkundel/code-dot-talks-2017-coffee-dot-js-how-i-hacked-my-coffee-machine-using-javascript'
     links: []

--- a/content/meetups/2018-01-31.md
+++ b/content/meetups/2018-01-31.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Haroen
         url: 'https://twitter.com/haroenv'
-        avatar: 'https://avatars.io/twitter/haroenv'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&embed=image.url'
     slides: ['https://haroen.me/presentations/en/api-client/apiclient.pdf']
     links: ['https://haroen.me/presentations/en/api-client/']
     videos: ['https://twitter.com/mauriz/status/958768177252618240']
@@ -36,7 +36,7 @@ talks:
     authors:
       - name: Vladimir
         url: 'https://twitter.com/poledesfetes'
-        avatar: 'https://avatars.io/twitter/poledesfetes'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&embed=image.url'
     slides:
       - 'http://slides.com/vladimirdeturckheim/deck-12#/'
     links: []

--- a/content/meetups/2018-01-31.md
+++ b/content/meetups/2018-01-31.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: Haroen
         url: 'https://twitter.com/haroenv'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&amps;embed=image.url'
     slides: ['https://haroen.me/presentations/en/api-client/apiclient.pdf']
     links: ['https://haroen.me/presentations/en/api-client/']
     videos: ['https://twitter.com/mauriz/status/958768177252618240']
@@ -36,7 +36,7 @@ talks:
     authors:
       - name: Vladimir
         url: 'https://twitter.com/poledesfetes'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&amps;embed=image.url'
     slides:
       - 'http://slides.com/vladimirdeturckheim/deck-12#/'
     links: []

--- a/content/meetups/2018-02-28.md
+++ b/content/meetups/2018-02-28.md
@@ -18,7 +18,7 @@ talks:
     authors:
       - name: Nicolas
         url: 'https://twitter.com/nhacsam_'
-        avatar: 'https://avatars.io/twitter/nhacsam_'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nhacsam_&embed=image.url'
     slides: []
     links: []
     videos: ['https://www.pscp.tv/mauriz1/1djGXdmaDnNGZ?t=30m30s']
@@ -29,7 +29,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://avatars.io/twitter/harrisfreddy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
     slides:
         - 'http://react-navigation-keynote.surge.sh/'
     links: []

--- a/content/meetups/2018-02-28.md
+++ b/content/meetups/2018-02-28.md
@@ -18,7 +18,7 @@ talks:
     authors:
       - name: Nicolas
         url: 'https://twitter.com/nhacsam_'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/nhacsam_&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nhacsam_&amps;embed=image.url'
     slides: []
     links: []
     videos: ['https://www.pscp.tv/mauriz1/1djGXdmaDnNGZ?t=30m30s']
@@ -29,7 +29,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&amps;embed=image.url'
     slides:
         - 'http://react-navigation-keynote.surge.sh/'
     links: []

--- a/content/meetups/2018-03-28.md
+++ b/content/meetups/2018-03-28.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: Haroen
         url: 'https://twitter.com/haroenv'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&amps;embed=image.url'
     slides: 
         - 'https://haroen.me/presentations/en/yarn-search/'
     links: []
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
     slides: 
         - https://speakerdeck.com/bloodyowl/third-party-hell
     links: []

--- a/content/meetups/2018-03-28.md
+++ b/content/meetups/2018-03-28.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: Haroen
         url: 'https://twitter.com/haroenv'
-        avatar: 'https://avatars.io/twitter/haroenv'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&embed=image.url'
     slides: 
         - 'https://haroen.me/presentations/en/yarn-search/'
     links: []
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://avatars.io/twitter/bloodyowl'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
     slides: 
         - https://speakerdeck.com/bloodyowl/third-party-hell
     links: []

--- a/content/meetups/2018-04-25.md
+++ b/content/meetups/2018-04-25.md
@@ -16,7 +16,7 @@ talks:
     authors:
       - name: Vincent
         url: 'https://twitter.com/Vince_Vallet'
-        avatar: 'https://avatars.io/twitter/Vince_Vallet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&embed=image.url'
     slides: []
     links: []
     videos: []
@@ -30,7 +30,7 @@ talks:
     authors:
       - name: Nicolas
         url: 'https://twitter.com/nhacsam_'
-        avatar: 'https://avatars.io/twitter/nhacsam_'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nhacsam_&embed=image.url'
     slides: 
         - https://t.co/kiEUSol7oq
     links: []
@@ -41,7 +41,7 @@ talks:
     authors:
       - name: Cyrille
         url: 'https://twitter.com/JesmoDrazik'
-        avatar: 'https://avatars.io/twitter/JesmoDrazik'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JesmoDrazik&embed=image.url'
     slides: 
         - https://t.co/WGqHomHj3d
     links: []

--- a/content/meetups/2018-04-25.md
+++ b/content/meetups/2018-04-25.md
@@ -16,7 +16,7 @@ talks:
     authors:
       - name: Vincent
         url: 'https://twitter.com/Vince_Vallet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&amps;embed=image.url'
     slides: []
     links: []
     videos: []
@@ -30,7 +30,7 @@ talks:
     authors:
       - name: Nicolas
         url: 'https://twitter.com/nhacsam_'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/nhacsam_&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nhacsam_&amps;embed=image.url'
     slides: 
         - https://t.co/kiEUSol7oq
     links: []
@@ -41,7 +41,7 @@ talks:
     authors:
       - name: Cyrille
         url: 'https://twitter.com/JesmoDrazik'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/JesmoDrazik&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JesmoDrazik&amps;embed=image.url'
     slides: 
         - https://t.co/WGqHomHj3d
     links: []

--- a/content/meetups/2018-05-30.md
+++ b/content/meetups/2018-05-30.md
@@ -19,7 +19,7 @@ talks:
     authors:
       - name: 'Adrien Joly'
         url: 'http://twitter.com/adrienjoly'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&amps;embed=image.url'
     slides:
         - 'http://adrienjoly.com/slides/testing'
     links:
@@ -32,7 +32,7 @@ talks:
     authors:
       - name: 'Mathieu'
         url: 'http://twitter.com/zoontek'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/zoontek&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/zoontek&amps;embed=image.url'
     slides:
         - 'https://speakerdeck.com/zoontek/manage-microservices-like-a-chef'
     links: []
@@ -49,7 +49,7 @@ talks:
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2018-05-30.md
+++ b/content/meetups/2018-05-30.md
@@ -19,7 +19,7 @@ talks:
     authors:
       - name: 'Adrien Joly'
         url: 'http://twitter.com/adrienjoly'
-        avatar: 'https://avatars.io/twitter/adrienjoly'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&embed=image.url'
     slides:
         - 'http://adrienjoly.com/slides/testing'
     links:
@@ -32,7 +32,7 @@ talks:
     authors:
       - name: 'Mathieu'
         url: 'http://twitter.com/zoontek'
-        avatar: 'https://avatars.io/twitter/zoontek'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/zoontek&embed=image.url'
     slides:
         - 'https://speakerdeck.com/zoontek/manage-microservices-like-a-chef'
     links: []
@@ -49,7 +49,7 @@ talks:
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
-        avatar: 'https://avatars.io/twitter/loicortola'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2018-06-27.md
+++ b/content/meetups/2018-06-27.md
@@ -16,7 +16,7 @@ talks:
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
-        avatar: 'https://avatars.io/twitter/loicortola'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&embed=image.url'
     slides: []
     links: []
     videos:
@@ -29,7 +29,7 @@ talks:
     authors:
       - name: 'Anta'
         url: 'https://twitter.com/aidaraanta'
-        avatar: 'https://avatars.io/twitter/aidaraanta'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/aidaraanta&embed=image.url'
     slides:
         - 'https://slides.com/antamb/deep-shit-aka-deep-learning-dans-le-navigateur#/'
     links: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: 'Loïc Carbonne'
         url: 'https://twitter.com/loiccarbonne'
-        avatar: 'https://avatars.io/twitter/loiccarbonne'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/loiccarbonne&embed=image.url'
     slides:
         - 'https://slides.com/loiccarbonne/deck-5-3#/'
     links: []

--- a/content/meetups/2018-06-27.md
+++ b/content/meetups/2018-06-27.md
@@ -16,7 +16,7 @@ talks:
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&amps;embed=image.url'
     slides: []
     links: []
     videos:
@@ -29,7 +29,7 @@ talks:
     authors:
       - name: 'Anta'
         url: 'https://twitter.com/aidaraanta'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/aidaraanta&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/aidaraanta&amps;embed=image.url'
     slides:
         - 'https://slides.com/antamb/deep-shit-aka-deep-learning-dans-le-navigateur#/'
     links: []
@@ -46,7 +46,7 @@ talks:
     authors:
       - name: 'Loïc Carbonne'
         url: 'https://twitter.com/loiccarbonne'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/loiccarbonne&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/loiccarbonne&amps;embed=image.url'
     slides:
         - 'https://slides.com/loiccarbonne/deck-5-3#/'
     links: []

--- a/content/meetups/2018-08-29.md
+++ b/content/meetups/2018-08-29.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: 'Adrien Trauth'
         url: 'http://twitter.com/nioufe'
-        avatar: 'https://avatars.io/twitter/nioufe'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nioufe&embed=image.url'
     slides:
         - http://dtdg.co/advanced-search
     links: []
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: 'Doug Sillars'
         url: 'http://twitter.com/dougsillars'
-        avatar: 'https://avatars.io/twitter/dougsillars'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/dougsillars&embed=image.url'
     slides:
         - https://www.slideshare.net/dougsillars/
     links: []
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
-        avatar: 'https://avatars.io/twitter/loicortola'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2018-08-29.md
+++ b/content/meetups/2018-08-29.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: 'Adrien Trauth'
         url: 'http://twitter.com/nioufe'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/nioufe&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nioufe&amps;embed=image.url'
     slides:
         - http://dtdg.co/advanced-search
     links: []
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: 'Doug Sillars'
         url: 'http://twitter.com/dougsillars'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/dougsillars&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/dougsillars&amps;embed=image.url'
     slides:
         - https://www.slideshare.net/dougsillars/
     links: []
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/loicortola&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2018-08-30.md
+++ b/content/meetups/2018-08-30.md
@@ -13,10 +13,10 @@ talks:
     authors:
       - name: 'Matthieu Kern'
         url: 'http://twitter.com/MatthieuKern'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/MatthieuKern&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/MatthieuKern&amps;embed=image.url'
       - name: 'Quentin Ménoret'
         url: 'http://twitter.com/QuentinMenoret'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/QuentinMenoret&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/QuentinMenoret&amps;embed=image.url'
     slides:
         - https://fr.slideshare.net/MatthieuKern1/how-to-connect-1980-and-2018
     links: []
@@ -30,7 +30,7 @@ talks:
     authors:
       - name: Maël Nison
         url: 'https://twitter.com/arcanis'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&amps;embed=image.url'
     slides: []
     links:
         - https://yarnpkg.com
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: 'Jonathan'
         url: 'http://twitter.com/captainjojo42'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/captainjojo42&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/captainjojo42&amps;embed=image.url'
     slides:
         - https://fr.slideshare.net/jonathanjalouzot/graphql-with-apollojs
     links:

--- a/content/meetups/2018-08-30.md
+++ b/content/meetups/2018-08-30.md
@@ -13,10 +13,10 @@ talks:
     authors:
       - name: 'Matthieu Kern'
         url: 'http://twitter.com/MatthieuKern'
-        avatar: 'https://avatars.io/twitter/MatthieuKern'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/MatthieuKern&embed=image.url'
       - name: 'Quentin Ménoret'
         url: 'http://twitter.com/QuentinMenoret'
-        avatar: 'https://avatars.io/twitter/QuentinMenoret'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/QuentinMenoret&embed=image.url'
     slides:
         - https://fr.slideshare.net/MatthieuKern1/how-to-connect-1980-and-2018
     links: []
@@ -30,7 +30,7 @@ talks:
     authors:
       - name: Maël Nison
         url: 'https://twitter.com/arcanis'
-        avatar: 'https://avatars.io/twitter/arcanis'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&embed=image.url'
     slides: []
     links:
         - https://yarnpkg.com
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: 'Jonathan'
         url: 'http://twitter.com/captainjojo42'
-        avatar: 'https://avatars.io/twitter/captainjojo42'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/captainjojo42&embed=image.url'
     slides:
         - https://fr.slideshare.net/jonathanjalouzot/graphql-with-apollojs
     links:

--- a/content/meetups/2018-10-24.md
+++ b/content/meetups/2018-10-24.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: 'Vincent Vallet'
         url: 'http://twitter.com/vince_vallet'
-        avatar: 'https://avatars.io/twitter/vince_vallet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/vince_vallet&embed=image.url'
     slides:
         - https://docs.google.com/presentation/d/17PXOZXBgdJHqBZlbULHg70_hVFLrNx9T34rB9bLDn2M/edit?usp=sharing
     links: []
@@ -39,7 +39,7 @@ talks:
     authors:
       - name: 'Maurice Svay'
         url: 'http://twitter.com/mauriz'
-        avatar: 'https://avatars.io/twitter/mauriz'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/mauriz&embed=image.url'
     slides:
         - https://docs.google.com/presentation/d/1QLnCls-OUj_iBwi-Y7oi-x2VXT20oAsZcOnJHTJKjjU/edit?usp=sharing
     links: []
@@ -54,7 +54,7 @@ talks:
     authors:
       - name: 'Christophe Rosset'
         url: 'http://twitter.com/topheman'
-        avatar: 'https://avatars.io/twitter/topheman'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2018-10-24.md
+++ b/content/meetups/2018-10-24.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: 'Vincent Vallet'
         url: 'http://twitter.com/vince_vallet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/vince_vallet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/vince_vallet&amps;embed=image.url'
     slides:
         - https://docs.google.com/presentation/d/17PXOZXBgdJHqBZlbULHg70_hVFLrNx9T34rB9bLDn2M/edit?usp=sharing
     links: []
@@ -39,7 +39,7 @@ talks:
     authors:
       - name: 'Maurice Svay'
         url: 'http://twitter.com/mauriz'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/mauriz&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/mauriz&amps;embed=image.url'
     slides:
         - https://docs.google.com/presentation/d/1QLnCls-OUj_iBwi-Y7oi-x2VXT20oAsZcOnJHTJKjjU/edit?usp=sharing
     links: []
@@ -54,7 +54,7 @@ talks:
     authors:
       - name: 'Christophe Rosset'
         url: 'http://twitter.com/topheman'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2018-11-07.md
+++ b/content/meetups/2018-11-07.md
@@ -23,10 +23,10 @@ talks:
     authors:
       - name: 'Vladimir de Turckheim'
         url: 'http://twitter.com/poledesfetes'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&amps;embed=image.url'
       - name: 'Jean-Baptiste Aviat'
         url: 'http://twitter.com/JbAviat'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/JbAviat&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JbAviat&amps;embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2018-11-07.md
+++ b/content/meetups/2018-11-07.md
@@ -23,10 +23,10 @@ talks:
     authors:
       - name: 'Vladimir de Turckheim'
         url: 'http://twitter.com/poledesfetes'
-        avatar: 'https://avatars.io/twitter/poledesfetes'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&embed=image.url'
       - name: 'Jean-Baptiste Aviat'
         url: 'http://twitter.com/JbAviat'
-        avatar: 'https://avatars.io/twitter/JbAviat'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JbAviat&embed=image.url'
     slides: []
     links: []
     videos:

--- a/content/meetups/2018-11-28.md
+++ b/content/meetups/2018-11-28.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://avatars.io/twitter/harrisfreddy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
     slides:
       - http://react-native-animated-keynote.surge.sh/
     links:

--- a/content/meetups/2018-11-28.md
+++ b/content/meetups/2018-11-28.md
@@ -26,7 +26,7 @@ talks:
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&amps;embed=image.url'
     slides:
       - http://react-native-animated-keynote.surge.sh/
     links:

--- a/content/meetups/2019-01-30.md
+++ b/content/meetups/2019-01-30.md
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Jacopo Daeli
         url: 'http://www.jacopodaeli.com'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&amps;embed=image.url'
     slides:
       - https://docs.google.com/presentation/d/17hJzgcRqke4gXjKQIF_U8tyR-ssBgi593ZqVKUBVB2M/edit#slide=id.g4e7fa82987_0_58
     links:

--- a/content/meetups/2019-01-30.md
+++ b/content/meetups/2019-01-30.md
@@ -31,7 +31,7 @@ talks:
     authors:
       - name: Jacopo Daeli
         url: 'http://www.jacopodaeli.com'
-        avatar: 'https://avatars.io/twitter/JacopoDaeli'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JacopoDaeli&embed=image.url'
     slides:
       - https://docs.google.com/presentation/d/17hJzgcRqke4gXjKQIF_U8tyR-ssBgi593ZqVKUBVB2M/edit#slide=id.g4e7fa82987_0_58
     links:

--- a/content/meetups/2019-02-27.md
+++ b/content/meetups/2019-02-27.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: 'Alexandre Moureaux'
         url: 'https://twitter.com/almouro'
-        avatar: 'https://avatars.io/twitter/almouro'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/almouro&embed=image.url'
     slides:
       - https://slides.com/alexandremoureaux/debugging-a-non-reproducible-crash#/
     links:
@@ -27,7 +27,7 @@ talks:
     authors:
       - name: 'Charly Poly'
         url: 'https://twitter.com/whereischarly'
-        avatar: 'https://avatars.io/twitter/whereischarly'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/whereischarly&embed=image.url'
     slides:
       - https://slides.com/charlypoly-1/deck-9
     links: []
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://avatars.io/twitter/bloodyowl'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
     slides:
       - https://speakerdeck.com/bloodyowl/best-practices
     links: []

--- a/content/meetups/2019-02-27.md
+++ b/content/meetups/2019-02-27.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: 'Alexandre Moureaux'
         url: 'https://twitter.com/almouro'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/almouro&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/almouro&amps;embed=image.url'
     slides:
       - https://slides.com/alexandremoureaux/debugging-a-non-reproducible-crash#/
     links:
@@ -27,7 +27,7 @@ talks:
     authors:
       - name: 'Charly Poly'
         url: 'https://twitter.com/whereischarly'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/whereischarly&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/whereischarly&amps;embed=image.url'
     slides:
       - https://slides.com/charlypoly-1/deck-9
     links: []
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
     slides:
       - https://speakerdeck.com/bloodyowl/best-practices
     links: []

--- a/content/meetups/2019-03-27.md
+++ b/content/meetups/2019-03-27.md
@@ -29,7 +29,7 @@ talks:
     authors:
       - name: 'William Gorge'
         url: 'https://twitter.com/wgorgedev'
-        avatar: 'https://avatars.io/twitter/wgorgedev'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/wgorgedev&embed=image.url'
     slides:
       - https://docs.google.com/presentation/d/1B6zk3VjbsveVcDgq5mKJ1EP2buhBk9auDVh77jQPLsU/edit#slide=id.p
     links: []
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: 'Adrien Joly'
         url: 'http://twitter.com/adrienjoly'
-        avatar: 'https://avatars.io/twitter/adrienjoly'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&embed=image.url'
     slides:
       - https://docs.google.com/presentation/d/1eVk1Px99bk-5BGKYL3MjZuQQqRezHVwtPiGFynBtsyE/edit?usp=sharing
     links:
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: 'Jérémy Wimsingues'
         url: 'https://twitter.com/JWimsingues'
-        avatar: 'https://avatars.io/twitter/JWimsingues'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JWimsingues&embed=image.url'
     slides:
       - https://docs.google.com/presentation/d/1Sy-4T-Nj4tyj07FeQhUIFNsFOtu9vlWnXXQt4RKVHSY/edit?usp=sharing
     links: []

--- a/content/meetups/2019-03-27.md
+++ b/content/meetups/2019-03-27.md
@@ -29,7 +29,7 @@ talks:
     authors:
       - name: 'William Gorge'
         url: 'https://twitter.com/wgorgedev'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/wgorgedev&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/wgorgedev&amps;embed=image.url'
     slides:
       - https://docs.google.com/presentation/d/1B6zk3VjbsveVcDgq5mKJ1EP2buhBk9auDVh77jQPLsU/edit#slide=id.p
     links: []
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: 'Adrien Joly'
         url: 'http://twitter.com/adrienjoly'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&amps;embed=image.url'
     slides:
       - https://docs.google.com/presentation/d/1eVk1Px99bk-5BGKYL3MjZuQQqRezHVwtPiGFynBtsyE/edit?usp=sharing
     links:
@@ -55,7 +55,7 @@ talks:
     authors:
       - name: 'Jérémy Wimsingues'
         url: 'https://twitter.com/JWimsingues'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/JWimsingues&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/JWimsingues&amps;embed=image.url'
     slides:
       - https://docs.google.com/presentation/d/1Sy-4T-Nj4tyj07FeQhUIFNsFOtu9vlWnXXQt4RKVHSY/edit?usp=sharing
     links: []

--- a/content/meetups/2019-04-24.md
+++ b/content/meetups/2019-04-24.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: 'Augustin Le Fèvre '
         url: 'https://twitter.com/gusguslf'
-        avatar: 'https://avatars.io/twitter/gusguslf'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gusguslf&embed=image.url'
     slides:
       - https://talk-codemods-paris-js.augustinlf.now.sh/.
     links:
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: 'Haroen Viaene'
         url: 'https://twitter.com/haroenv'
-        avatar: 'https://avatars.io/twitter/haroenv'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&embed=image.url'
     slides:
       - https://haroen.me/presentations/en/abstract-components/
     links: []

--- a/content/meetups/2019-04-24.md
+++ b/content/meetups/2019-04-24.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: 'Augustin Le Fèvre '
         url: 'https://twitter.com/gusguslf'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/gusguslf&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/gusguslf&amps;embed=image.url'
     slides:
       - https://talk-codemods-paris-js.augustinlf.now.sh/.
     links:
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: 'Haroen Viaene'
         url: 'https://twitter.com/haroenv'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&amps;embed=image.url'
     slides:
       - https://haroen.me/presentations/en/abstract-components/
     links: []

--- a/content/meetups/2019-05-29.md
+++ b/content/meetups/2019-05-29.md
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: 'Thomas Dubois'
         url: 'https://twitter.com/thodubois'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/thodubois&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/thodubois&amps;embed=image.url'
     slides:
       - https://slides.com/fromwood/deck
     videos:
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: 'Louis Lagrange'
         url: 'https://twitter.com/Minishlink'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Minishlink&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Minishlink&amps;embed=image.url'
     videos:
       - https://youtu.be/StGBIJzwEis
 ---

--- a/content/meetups/2019-05-29.md
+++ b/content/meetups/2019-05-29.md
@@ -23,7 +23,7 @@ talks:
     authors:
       - name: 'Thomas Dubois'
         url: 'https://twitter.com/thodubois'
-        avatar: 'https://avatars.io/twitter/thodubois'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/thodubois&embed=image.url'
     slides:
       - https://slides.com/fromwood/deck
     videos:
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: 'Louis Lagrange'
         url: 'https://twitter.com/Minishlink'
-        avatar: 'https://avatars.io/twitter/Minishlink'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Minishlink&embed=image.url'
     videos:
       - https://youtu.be/StGBIJzwEis
 ---

--- a/content/meetups/2019-06-26.md
+++ b/content/meetups/2019-06-26.md
@@ -19,7 +19,7 @@ talks:
     authors:
       - name: 'Vladimir de Turckheim'
         url: 'https://twitter.com/poledesfetes'
-        avatar: 'https://avatars.io/twitter/poledesfetes'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&embed=image.url'
     videos:
       - https://youtu.be/-hQw-tbIQ-E
   - title: "Utiliser WebAssembly, dès aujourd'hui"
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: 'Christophe Rosset'
         url: 'https://twitter.com/topheman'
-        avatar: 'https://avatars.io/twitter/topheman'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&embed=image.url'
     videos:
       - https://youtu.be/F3wOfWIFzVc
     links:
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: 'Elia Maino'
         url: 'https://twitter.com/eliamain'
-        avatar: 'https://avatars.io/twitter/eliamain'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/eliamain&embed=image.url'
     videos:
       - https://youtu.be/nOG0lHpRxQ8
 ---

--- a/content/meetups/2019-06-26.md
+++ b/content/meetups/2019-06-26.md
@@ -19,7 +19,7 @@ talks:
     authors:
       - name: 'Vladimir de Turckheim'
         url: 'https://twitter.com/poledesfetes'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/poledesfetes&amps;embed=image.url'
     videos:
       - https://youtu.be/-hQw-tbIQ-E
   - title: "Utiliser WebAssembly, dès aujourd'hui"
@@ -34,7 +34,7 @@ talks:
     authors:
       - name: 'Christophe Rosset'
         url: 'https://twitter.com/topheman'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/topheman&amps;embed=image.url'
     videos:
       - https://youtu.be/F3wOfWIFzVc
     links:
@@ -45,7 +45,7 @@ talks:
     authors:
       - name: 'Elia Maino'
         url: 'https://twitter.com/eliamain'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/eliamain&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/eliamain&amps;embed=image.url'
     videos:
       - https://youtu.be/nOG0lHpRxQ8
 ---

--- a/content/meetups/2019-09-25.md
+++ b/content/meetups/2019-09-25.md
@@ -14,7 +14,7 @@ talks:
     authors:
       - name: 'Foucauld Degeorges'
         url: 'https://twitter.com/foucdeg'
-        avatar: 'https://avatars.io/twitter/foucdeg'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/foucdeg&embed=image.url'
     slides:
       - https://slides.com/foucaulddegeorges/electron
     videos:
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: 'Albéric Trancart'
         url: 'https://twitter.com/alberictrancart'
-        avatar: 'https://avatars.io/twitter/alberictrancart'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alberictrancart&embed=image.url'
     videos:
       - https://youtu.be/3ztP8ujDkhI
   - title: 'La conversion de type en JavaScript'
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: 'Stanislas Ormières'
         url: 'https://twitter.com/laruiss'
-        avatar: 'https://avatars.io/twitter/laruiss'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/laruiss&embed=image.url'
     slides:
       - https://slides.com/stormier/type-coercion-in-js
     videos:

--- a/content/meetups/2019-09-25.md
+++ b/content/meetups/2019-09-25.md
@@ -14,7 +14,7 @@ talks:
     authors:
       - name: 'Foucauld Degeorges'
         url: 'https://twitter.com/foucdeg'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/foucdeg&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/foucdeg&amps;embed=image.url'
     slides:
       - https://slides.com/foucaulddegeorges/electron
     videos:
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: 'Albéric Trancart'
         url: 'https://twitter.com/alberictrancart'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/alberictrancart&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/alberictrancart&amps;embed=image.url'
     videos:
       - https://youtu.be/3ztP8ujDkhI
   - title: 'La conversion de type en JavaScript'
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: 'Stanislas Ormières'
         url: 'https://twitter.com/laruiss'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/laruiss&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/laruiss&amps;embed=image.url'
     slides:
       - https://slides.com/stormier/type-coercion-in-js
     videos:

--- a/content/meetups/2019-10-30.md
+++ b/content/meetups/2019-10-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: 'Maël Nison'
         url: 'https://twitter.com/arcanis'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&amps;embed=image.url'
     links:
       - https://github.com/yarnpkg/berry
     videos:
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: 'Nicolas Dubien'
         url: 'https://twitter.com/ndubien'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/ndubien&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/ndubien&amps;embed=image.url'
     slides:
       - https://dubzzz.github.io/fast-check.github.com/talks/meetup-typescript-04092018/property-based-testing.html
     links:
@@ -48,7 +48,7 @@ talks:
     authors:
       - name: 'Maxime Sraiki'
         url: 'https://twitter.com/MaximeSraiki'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/MaximeSraiki&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/MaximeSraiki&amps;embed=image.url'
     videos:
       - https://youtu.be/5Nzuyu0u6T4
   - title: 'How to refactor your API without bugs using GraphQL and static type-checking'
@@ -57,7 +57,7 @@ talks:
     authors:
       - name: 'Bastien Duret'
         url: 'https://twitter.com/bast0che'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bast0che&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bast0che&amps;embed=image.url'
     videos:
       - https://youtu.be/AzM1i8-hc2w
 ---

--- a/content/meetups/2019-10-30.md
+++ b/content/meetups/2019-10-30.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: 'Maël Nison'
         url: 'https://twitter.com/arcanis'
-        avatar: 'https://avatars.io/twitter/arcanis'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&embed=image.url'
     links:
       - https://github.com/yarnpkg/berry
     videos:
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: 'Nicolas Dubien'
         url: 'https://twitter.com/ndubien'
-        avatar: 'https://avatars.io/twitter/ndubien'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/ndubien&embed=image.url'
     slides:
       - https://dubzzz.github.io/fast-check.github.com/talks/meetup-typescript-04092018/property-based-testing.html
     links:
@@ -48,7 +48,7 @@ talks:
     authors:
       - name: 'Maxime Sraiki'
         url: 'https://twitter.com/MaximeSraiki'
-        avatar: 'https://avatars.io/twitter/MaximeSraiki'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/MaximeSraiki&embed=image.url'
     videos:
       - https://youtu.be/5Nzuyu0u6T4
   - title: 'How to refactor your API without bugs using GraphQL and static type-checking'
@@ -57,7 +57,7 @@ talks:
     authors:
       - name: 'Bastien Duret'
         url: 'https://twitter.com/bast0che'
-        avatar: 'https://avatars.io/twitter/bast0che'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bast0che&embed=image.url'
     videos:
       - https://youtu.be/AzM1i8-hc2w
 ---

--- a/content/meetups/2019-11-27.md
+++ b/content/meetups/2019-11-27.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: 'Guillaume Plique'
         url: 'https://twitter.com/Yomguithereal'
-        avatar: 'https://avatars.io/twitter/Yomguithereal'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Yomguithereal&embed=image.url'
     slides:
       - https://yomguithereal.github.io/mnemonist/presentations/fosdem2019/#0
     videos:
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: 'Eric Le Merdy'
         url: 'https://twitter.com/ericlemerdy'
-        avatar: 'https://avatars.io/twitter/ericlemerdy'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/ericlemerdy&embed=image.url'
     links:
       - https://one2team.com/
     videos:

--- a/content/meetups/2019-11-27.md
+++ b/content/meetups/2019-11-27.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: 'Guillaume Plique'
         url: 'https://twitter.com/Yomguithereal'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Yomguithereal&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Yomguithereal&amps;embed=image.url'
     slides:
       - https://yomguithereal.github.io/mnemonist/presentations/fosdem2019/#0
     videos:
@@ -25,7 +25,7 @@ talks:
     authors:
       - name: 'Eric Le Merdy'
         url: 'https://twitter.com/ericlemerdy'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/ericlemerdy&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/ericlemerdy&amps;embed=image.url'
     links:
       - https://one2team.com/
     videos:

--- a/content/meetups/2019-12-05.md
+++ b/content/meetups/2019-12-05.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: 'Alex Stanislawski'
         url: 'https://twitter.com/bobylito'
-        avatar: 'https://avatars.io/twitter/bobylito'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url'
   - title: 'About Svelte'
     extract: >
       "Yet another JavaScript component framework ? Seriously ? 
@@ -21,12 +21,12 @@ talks:
     authors:
       - name: 'Bertrand Chevrier'
         url: 'https://twitter.com/kramp'
-        avatar: 'https://avatars.io/twitter/kramp'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/kramp&embed=image.url'
   - title: 'The NodeBots band: creating and augmenting music with JS and WebAssembly'
     extract: >
       This talk is about the importance of art and play in Node, about the abilities Node has gained in its ten years as a project. There's a musical number and a discussion of MIDI as a way to send data. Let's dive into the ways Node can be used that we don't always think about.
     authors:
       - name: 'Mx. Kassian Wren'
         url: 'https://twitter.com/nodebotanist'
-        avatar: 'https://avatars.io/twitter/nodebotanist'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nodebotanist&embed=image.url'
 ---

--- a/content/meetups/2019-12-05.md
+++ b/content/meetups/2019-12-05.md
@@ -13,7 +13,7 @@ talks:
     authors:
       - name: 'Alex Stanislawski'
         url: 'https://twitter.com/bobylito'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&amps;embed=image.url'
   - title: 'About Svelte'
     extract: >
       "Yet another JavaScript component framework ? Seriously ? 
@@ -21,12 +21,12 @@ talks:
     authors:
       - name: 'Bertrand Chevrier'
         url: 'https://twitter.com/kramp'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/kramp&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/kramp&amps;embed=image.url'
   - title: 'The NodeBots band: creating and augmenting music with JS and WebAssembly'
     extract: >
       This talk is about the importance of art and play in Node, about the abilities Node has gained in its ten years as a project. There's a musical number and a discussion of MIDI as a way to send data. Let's dive into the ways Node can be used that we don't always think about.
     authors:
       - name: 'Mx. Kassian Wren'
         url: 'https://twitter.com/nodebotanist'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/nodebotanist&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/nodebotanist&amps;embed=image.url'
 ---

--- a/content/meetups/2020-01-29.md
+++ b/content/meetups/2020-01-29.md
@@ -16,7 +16,7 @@ talks:
     authors:
       - name: 'Vincent Vallet'
         url: 'https://twitter.com/Vince_Vallet'
-        avatar: 'https://avatars.io/twitter/Vince_Vallet'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&embed=image.url'
     videos:
       - https://www.youtube.com/watch?v=WrJw3Is_-Cs
   - title: 'Faites bien plus que des tests avec votre CI tout en la maintenant sous les 5 minutes'
@@ -28,7 +28,7 @@ talks:
     authors:
       - name: 'Aurélien Le Masson'
         url: 'https://twitter.com/aurelien__lm'
-        avatar: 'https://avatars.io/twitter/aurelien__lm'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/aurelien__lm&embed=image.url'
     videos:
       - https://www.youtube.com/watch?v=WwzXePktNxs
     slides:
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: 'Thomas Dubois'
         url: 'https://twitter.com/ThoDubois'
-        avatar: 'https://avatars.io/twitter/ThoDubois'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/ThoDubois&embed=image.url'
     videos:
       - https://www.youtube.com/watch?v=oAoQhBAThzw
 ---

--- a/content/meetups/2020-01-29.md
+++ b/content/meetups/2020-01-29.md
@@ -16,7 +16,7 @@ talks:
     authors:
       - name: 'Vincent Vallet'
         url: 'https://twitter.com/Vince_Vallet'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/Vince_Vallet&amps;embed=image.url'
     videos:
       - https://www.youtube.com/watch?v=WrJw3Is_-Cs
   - title: 'Faites bien plus que des tests avec votre CI tout en la maintenant sous les 5 minutes'
@@ -28,7 +28,7 @@ talks:
     authors:
       - name: 'Aurélien Le Masson'
         url: 'https://twitter.com/aurelien__lm'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/aurelien__lm&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/aurelien__lm&amps;embed=image.url'
     videos:
       - https://www.youtube.com/watch?v=WwzXePktNxs
     slides:
@@ -42,7 +42,7 @@ talks:
     authors:
       - name: 'Thomas Dubois'
         url: 'https://twitter.com/ThoDubois'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/ThoDubois&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/ThoDubois&amps;embed=image.url'
     videos:
       - https://www.youtube.com/watch?v=oAoQhBAThzw
 ---

--- a/content/meetups/2020-02-26.md
+++ b/content/meetups/2020-02-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: 'Andrey Soloviev'
         url: 'https://twitter.com/MindRave'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/MindRave&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/MindRave&amps;embed=image.url'
     videos:
   - title: 'Real-world ReasonReact'
     extract: >
@@ -19,7 +19,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
     videos:
     slides:
   - title: "Server-side rendering, Twig, Vue, un ménage à 3 qui n'a pas fonctionné "
@@ -50,5 +50,5 @@ talks:
     authors:
       - name: 'Elie'
         url: 'https://twitter.com/elie_dutheil'
-        avatar: 'https://api.microlink.io/?url=https://twitter.com/elie_dutheil&embed=image.url'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/elie_dutheil&amps;embed=image.url'
 ---

--- a/content/meetups/2020-02-26.md
+++ b/content/meetups/2020-02-26.md
@@ -11,7 +11,7 @@ talks:
     authors:
       - name: 'Andrey Soloviev'
         url: 'https://twitter.com/MindRave'
-        avatar: 'https://avatars.io/twitter/MindRave'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/MindRave&embed=image.url'
     videos:
   - title: 'Real-world ReasonReact'
     extract: >
@@ -19,7 +19,7 @@ talks:
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
-        avatar: 'https://avatars.io/twitter/bloodyowl'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&embed=image.url'
     videos:
     slides:
   - title: "Server-side rendering, Twig, Vue, un ménage à 3 qui n'a pas fonctionné "
@@ -50,5 +50,5 @@ talks:
     authors:
       - name: 'Elie'
         url: 'https://twitter.com/elie_dutheil'
-        avatar: 'https://avatars.io/twitter/elie_dutheil'
+        avatar: 'https://api.microlink.io/?url=https://twitter.com/elie_dutheil&embed=image.url'
 ---


### PR DESCRIPTION
avatars.io n'existe plus :'(

Il y a un remplaçant https://unavatar.now.sh/ mais qui ne marche plus avec les liens twitter, par contre ils conseillent microlink.io https://github.com/Kikobeats/unavatar/issues/121#issuecomment-748018963

Les liens avatars.io sont générés par le code hellojs ?

<img width="1146" alt="Screenshot 2021-01-07 at 12 37 38" src="https://user-images.githubusercontent.com/2125859/103890596-9f4a1800-50e8-11eb-9cbe-5b3119305de5.png">
