### PR TITLE
Fix login on Safari

### DIFF
--- a/components/TalkSubmissionContainer.js
+++ b/components/TalkSubmissionContainer.js
@@ -24,7 +24,7 @@ try {
       github: 'Iv1.558c5d3bf74f6921'
     },
     {
-      redirect_uri: 'https://parisjs.org/propositions/sujet'
+      redirect_uri: 'https://parisjs.org/propositions/sujet/'
     }
   )
 } catch (e) {}


### PR DESCRIPTION
Fixes #190 

Explication du problème:
La redirect_uri ne fini pas par un "/" or cloudflare redirige vers `https://parisjs.org/propositions/sujet/` (avec un slash à la fin). Du coup on perd le token en cours de route dans le cas de Safari

<img width="1434" alt="Screenshot 2021-01-08 at 19 04 47" src="https://user-images.githubusercontent.com/2125859/104048974-68f1c300-51e4-11eb-9e13-5336a3eb3732.png">
