### PR TITLE
Fix multiline descriptions of presentations

### DIFF
--- a/content/meetups/2011-07-27.md
+++ b/content/meetups/2011-07-27.md
@@ -52,7 +52,7 @@ talks:
   - title: >-
       Retour d'expérience sur l'utilisation de PhoneGap pour des projets clients
       / internes
-    extract: >
+    extract: |
       Retour d'expérience sur l'utilisation de PhoneGap pour des projets clients
       / internes
     authors:

--- a/content/meetups/2012-04-25.md
+++ b/content/meetups/2012-04-25.md
@@ -8,7 +8,7 @@ talks:
   - title: >-
       HTML5 pour les jeux. Ce que j'ai appris en développant / encadrant 300
       productions.
-    extract: >
+    extract: |
       HTML5 pour les jeux. Ce que j'ai appris en développant / encadrant 300
       productions.
     authors:
@@ -82,4 +82,3 @@ talks:
     links: []
     videos: []
 ---
-

--- a/content/meetups/2012-07-25.md
+++ b/content/meetups/2012-07-25.md
@@ -45,7 +45,7 @@ talks:
   - title: >-
       Lightning talk : Processingjs: une visualisation pour les systèmes
       d'informations
-    extract: >
+    extract: |
       Lightning talk : Processingjs: une visualisation pour les systèmes
       d'informations
     authors:

--- a/content/meetups/2013-04-24.md
+++ b/content/meetups/2013-04-24.md
@@ -58,7 +58,7 @@ talks:
   - title: >-
       Server-sent events: l'API push qui inconnue qui mériterait de l'être un
       peu plus
-    extract: >
+    extract: |
       Server-sent events: l'API push qui inconnue qui mériterait de l'être un
       peu plus
     authors:

--- a/content/meetups/2013-10-30.md
+++ b/content/meetups/2013-10-30.md
@@ -21,7 +21,7 @@ talks:
   - title: >-
       ExoBrowser: The Experimentation Platform to Build a Next generation Web
       Browser
-    extract: >
+    extract: |
       ExoBrowser: The Experimentation Platform to Build a Next generation Web
       Browser
     authors:
@@ -65,4 +65,3 @@ talks:
       - >-
         http://www.dailymotion.com/video/x2kjz5c_parisjs-30-david-boureau-introduction-a-la-programmation-fonctionnelle-2-2_webcam
 ---
-

--- a/content/meetups/2014-06-25.md
+++ b/content/meetups/2014-06-25.md
@@ -8,7 +8,7 @@ talks:
   - title: >-
       Comment construire l'interface d'une application web mobile qui rivalise
       avec le natif
-    extract: >
+    extract: |
       Comment construire l'interface d'une application web mobile qui rivalise
       avec le natif
     authors:

--- a/content/meetups/2015-01-21.md
+++ b/content/meetups/2015-01-21.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/219909981/
 talks:
   - title: De Virtjs à Start9
-    extract: >
+    extract: |
       De Virtjs à Start9
 
 
@@ -32,7 +32,7 @@ talks:
       - 'http://m.start9.io'
     videos: []
   - title: 'Front-end Dev Avengers: pour un dev front avec feedback super-fluide'
-    extract: >
+    extract: |
       Front-end Dev Avengers: pour un dev front avec feedback super-fluide
 
 
@@ -71,7 +71,7 @@ talks:
   - title: >-
       ionicframework : affranchissons nous des problèmes du développement
       hybride sur mobile
-    extract: >
+    extract: |
       ionicframework : affranchissons nous des problèmes du développement
       hybride sur mobile
 

--- a/content/meetups/2015-02-26.md
+++ b/content/meetups/2015-02-26.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/220581681/
 talks:
   - title: Functional Reactive Programming with RxJS
-    extract: >2
+    extract: |2
        Functional Reactive Programming with RxJS
 
       J'utilise RxJS en prod depuis 1 an maintenant. Au delà du buzzword, quels
@@ -22,7 +22,7 @@ talks:
     links: []
     videos: []
   - title: The promise and the hack
-    extract: >2
+    extract: |2
        The promise and the hack
 
       Présentation en 5 minutes d'une solution permettant de lier des éléments
@@ -40,7 +40,7 @@ talks:
     links: []
     videos: []
   - title: 'AngularJS + ReactJS, pourquoi, comment ?'
-    extract: >2-
+    extract: |2-
        AngularJS + ReactJS, pourquoi, comment ?
 
       Améliorer les performances de ses applications AngularJS en intégrant des
@@ -55,7 +55,7 @@ talks:
       - 'https://github.com/revolunet/angular-react-meetup'
     videos: []
   - title: WebRTC made Simple
-    extract: >2
+    extract: |2
        WebRTC made Simple
 
       WebRTC a été conçu à la base pour faire de la visio-conférence sans plugin

--- a/content/meetups/2015-03-25.md
+++ b/content/meetups/2015-03-25.md
@@ -22,8 +22,8 @@ talks:
       - 'https://slidee.firebaseapp.com/presentations/parisjs/'
     links: []
     videos: []
-  - title: 'Comment gérer l''asynchrone : hier, aujourd''hui, demain et après demain'
-    extract: >2
+  - title: "Comment gérer l'asynchrone : hier, aujourd'hui, demain et après demain"
+    extract: |2
        Comment gérer l'asynchrone : hier, aujourd'hui, demain et après demain
 
       Ce n'est un secret pour personne, le JavaScript est un langage asynchrone,

--- a/content/meetups/2015-04-09.md
+++ b/content/meetups/2015-04-09.md
@@ -24,7 +24,7 @@ talks:
       - 'https://github.com/ThomasCrvsr/pragmatic-sweetjs'
     videos: []
   - title: Comment négocier son salaire avec tact et efficacité
-    extract: >
+    extract: |
       Gros pain point que j'ai observé à breaz : certains développeurs savent
       mal négocié leur salaire.
 

--- a/content/meetups/2015-04-29.md
+++ b/content/meetups/2015-04-29.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/222076585/
 talks:
   - title: Introduction à HAL
-    extract: >2
+    extract: |2
        Introduction à HAL
       Les API hypermedia font parler d'elles de plus en plus, à quoi
       ressemblent-elles concrètement ?
@@ -59,7 +59,7 @@ talks:
     links: []
     videos: []
   - title: Il est temps d'utiliser les Flexbox en CSS
-    extract: >
+    extract: |
       Présentation des propriétés CSS liées au "Flexible Box Layout", de la
       compatibilité navigateur aujourd'hui, des outils pour s'en servir plus
       simplement, et des examples de cas d'usage.

--- a/content/meetups/2015-05-27.md
+++ b/content/meetups/2015-05-27.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/222536393/
 talks:
   - title: ECMAScript 2015
-    extract: >
+    extract: |
       Le standard ECMAScript 2015 (ES6) doit être finalisé en juin.
 
 
@@ -23,7 +23,7 @@ talks:
     links: []
     videos: []
   - title: jQuery (2015) - The good parts
-    extract: >
+    extract: |
       Is jQuery always relevant today ? TL;DR Yep !
 
       Panorama des méthodes de jQuery utiles et efficaces : Manipulation
@@ -39,7 +39,7 @@ talks:
     links: []
     videos: []
   - title: Les linters
-    extract: >
+    extract: |
       Petite présentation de l'existant, de jslint jusqu'a eslint. Pourquoi
       utiliser un linters ?
     authors:
@@ -54,7 +54,7 @@ talks:
   - title: >-
       ng-admin, ou comment utiliser Angular et une API REST pour construire une
       interface d'administration
-    extract: >
+    extract: |
       Beaucoup de frameworks backend proposent des applications d'administration
       (Django admin, Symfony Sonata Admin, etc). Le problème est que les
       produits se basent de plus en plus sur de multiples applications. Faut-il

--- a/content/meetups/2015-06-24.md
+++ b/content/meetups/2015-06-24.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/223279758/
 talks:
   - title: CSS at scale
-    extract: >
+    extract: |
       A little reminder about how CSS let's you do shit and how you should
       embrace the BEM methodology to make your code easy to read and write.
     authors:
@@ -18,7 +18,7 @@ talks:
     links: []
     videos: []
   - title: ng-build
-    extract: >
+    extract: |
       ng-build est un build system prévu pour simplifier le développement
       d'applications AngularJS. Basé sur les noms de fichiers, il évite au
       programmeur d'avoir à taper du boilerplate pour déclarer ses modules,
@@ -34,7 +34,7 @@ talks:
       - 'https://github.com/izeau/ng-build'
     videos: []
   - title: Web Analytics Automation Testing – Data beats Opinions
-    extract: >
+    extract: |
       Web analytics implementation is much more complex than most people think.
       Testing Web Analytics remains a cumbersome and complex task. Basically we
       have 4 alternatives:
@@ -73,8 +73,8 @@ talks:
     slides: []
     links: []
     videos: []
-  - title: 'Websocket vs SSE, j''ai choisi mon camp'
-    extract: >
+  - title: "Websocket vs SSE, j'ai choisi mon camp"
+    extract: |
       La bataille fait rage entre SSE et Websocket. L'objectif est de détailler
       notre position sur le sujet, avec choix d’architectures etc.
     authors:

--- a/content/meetups/2015-09-30.md
+++ b/content/meetups/2015-09-30.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/225681677/
 talks:
   - title: Angular Universal
-    extract: >
+    extract: |
       Angular Universal apportera un support universel aux applications Angular
       2. En d'autres termes, les applications Angular 2 vont pouvoir tourner sur
       autre chose que des navigateurs.
@@ -20,7 +20,7 @@ talks:
       - 'https://github.com/angular/universal'
     videos: []
   - title: 'Happy Path, Sad Path'
-    extract: >
+    extract: |
       Sur Capitaine Train, le Happy Path (celui où tout se passe bien pour
       l’utilisateur) est très, très rapide. Une dizaine de clics tout au plus
       pour acheter un billet de train. Mais évidemment tout ne va pas toujours
@@ -48,7 +48,7 @@ talks:
       - 'https://www.captaintrain.com/'
     videos: []
   - title: Node v4
-    extract: >
+    extract: |
       Node 4.0.0 est enfin disponible !
 
 
@@ -65,7 +65,7 @@ talks:
       - 'https://nodejs.org'
     videos: []
   - title: Yo! Génère moi un Générateur
-    extract: >
+    extract: |
       Tu as toujours rêvé de créer ton propre générateur Yeoman ? Alors ce
       lightning est pour toi... Nous allons voir comment créer un générateur
       d'application Firefox OS avec Yeoman.

--- a/content/meetups/2015-10-28.md
+++ b/content/meetups/2015-10-28.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/226186527/
 talks:
   - title: After the render tree
-    extract: >
+    extract: |
       Je compte expliquer en détails les étapes qui viennent après le render
       tree dans le browser : layout/reflow, paint, composite. Le but étant de
       mieux comprendre ce qui se passe dans le navigateur pour créer des
@@ -28,7 +28,7 @@ talks:
     links: []
     videos: []
   - title: ClojureScript
-    extract: >
+    extract: |
       ClojureScript, un langage compile-to-js.
 
 
@@ -51,7 +51,7 @@ talks:
       - 'http://clojure.org/clojurescript'
     videos: []
   - title: npm3
-    extract: >
+    extract: |
       npm 3 est sorti de beta le mois dernier.
 
 
@@ -67,7 +67,7 @@ talks:
       - 'http://npmjs.com/'
     videos: []
   - title: Web Audio Jam
-    extract: >
+    extract: |
       Cette présentation expliquera les bases de l'API Web Audio : comment
       fonctionne la synthèse de son dans le browser ? Comment créer et manipuler
       du son ? Comment importer et écouter des fichiers d'audio ? Quels sont les

--- a/content/meetups/2015-11-25.md
+++ b/content/meetups/2015-11-25.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/226735183/
 talks:
   - title: gl-react
-    extract: >
+    extract: |
       gl-react permet de définir des effets pour React (web) et React-Native
       (native)
 
@@ -34,7 +34,7 @@ talks:
       - 'https://github.com/gre/gl-react-playground'
     videos: []
   - title: Other uses of JS
-    extract: >
+    extract: |
       A talk about my journey into "creative technology", with different
       projects I did, tools I use, and how JS fits into all of that.
 
@@ -77,7 +77,7 @@ talks:
       - 'http://treesmovethemost.com'
     videos: []
   - title: L'effet Service Workers
-    extract: >
+    extract: |
       Les Service Workers ont fini par arriver ! A ne pas confondre avec les
       "Web Workers", les Service Workers sont des "proxy" JS des requêtes HTTP
       des navigateurs. Ils vont offrir une foule de possibilités qui permettront
@@ -95,7 +95,7 @@ talks:
       - 'http://www.w3.org/TR/service-workers/'
     videos: []
   - title: Vue.js
-    extract: >
+    extract: |
       Vue est une alternative aux frameworks MVVM tels que Angular, React,
       Aurelia,
 

--- a/content/meetups/2016-01-27.md
+++ b/content/meetups/2016-01-27.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/228173692/
 talks:
   - title: Connexion via les réseaux sociaux avec Loopback et Satellizer
-    extract: >-
+    extract: |-
       J'ai développé un composant loopback pour me simplifier la connexion via
       les réseaux sociaux, ce qui me permet de mettre en place
       l'authentification sur mes sites webs en 1 minute au lieu d'une journée.
@@ -20,7 +20,7 @@ talks:
       - 'https://github.com/moooink/loopback-component-satellizer'
     videos: []
   - title: React / Redux - le duo gagnant
-    extract: >-
+    extract: |-
       L'intérêt de React n'est plus à démontrer. En le couplant à une solution
       telle que Redux pour gérer les données, il démontre encore plus sa
       puissance (et sa simplicité d'utilisation).
@@ -48,7 +48,7 @@ talks:
       - 'https://github.com/topheman/react-es6-redux'
     videos: []
   - title: 'Zombo Reloaded: Introduction to Webpack'
-    extract: >-
+    extract: |-
       Partons ensemble à la découverte de Webpack, le bundler universel, à
       travers la refonte de www.zombo.com en semi-live-coding.
     authors:

--- a/content/meetups/2016-02-24.md
+++ b/content/meetups/2016-02-24.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/228786403/
 talks:
   - title: 'CSS Grid Layout : le futur de vos mises en page'
-    extract: >
+    extract: |
       Faire des mises en pages avancées a toujours été une gageure en CSS.
 
 
@@ -34,7 +34,7 @@ talks:
       - 'https://drafts.csswg.org/css-grid/'
     videos: []
   - title: Gérer ses serveurs de dev et test avec PM2
-    extract: >
+    extract: |
       Le projet PM2 cible plutôt le suivi des processus Node en production. Pour
       autant, c’est un outil vraiment pratique pour administrer ses serveurs de
       développement et de test, par exemple lorsque l'on doit démarrer et
@@ -50,7 +50,7 @@ talks:
       - 'http://pm2.keymetrics.io/'
     videos: []
   - title: 'ES2016, et au delà'
-    extract: >
+    extract: |
       Après un ES6 / ES2015 très rempli, ES2016 sera très léger en nouvelles
       features. Point en 5 minutes sur ce que ça signifie, et sur ce que sera
       ensuite l'évolution du standard de JS.
@@ -64,7 +64,7 @@ talks:
       - 'https://github.com/tc39/ecma262'
     videos: []
   - title: HelicoJS
-    extract: >
+    extract: |
       Commander un helico RC Bluetooth beewi à 20€ dans le browser avec GamePAD
       API, Socket.IO, NodeJS, Bluez.
     authors:

--- a/content/meetups/2016-03-30.md
+++ b/content/meetups/2016-03-30.md
@@ -5,8 +5,8 @@ host: Leboncoin
 sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/228197861/
 talks:
-  - title: 'Du natif à l''application full js avec emscripten, node.js et angular,'
-    extract: >
+  - title: "Du natif à l'application full js avec emscripten, node.js et angular,"
+    extract: |
       Une vue large des principes de bases, des technologies et des languages
       utilisés dans la carto web :
 
@@ -31,7 +31,7 @@ talks:
     videos:
       - 'https://www.youtube.com/watch?v=wMW96Pa2aOY'
   - title: Un dev front dans la jungle des cartes
-    extract: >
+    extract: |
       Une vue large des principes de bases, des technologies et des languages
       utilisés dans la carto web :
 
@@ -57,8 +57,8 @@ talks:
       - 'https://cartodb.com/'
     videos:
       - 'https://www.youtube.com/watch?v=NavMz_421qk'
-  - title: 'Réagir à l''imprévu : Robustesse en AngularJS'
-    extract: >
+  - title: "Réagir à l'imprévu : Robustesse en AngularJS"
+    extract: |
       Réseau faible ou inexistant, absence de permissions de la part de
       l'utilisateur, pas de données disponibles : les applications sont
       aujourd'hui plus que jamais soumises à des situations inhabituelles.

--- a/content/meetups/2016-04-27.md
+++ b/content/meetups/2016-04-27.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/230298998/
 talks:
   - title: 'JSONWebToken, tu vas aimer ça plus fort que tes parents !'
-    extract: >
+    extract: |
       JSON Web Token, standard en devenir, est une solution d'authentification
       sans session coté backend, légère et simple à mettre en place, qui permet
       à deux parties de valider une requête ou non grace à l’échange d'un jeton
@@ -27,8 +27,8 @@ talks:
       - 'https://github.com/benjaminW78/json-web-token-introduction'
     videos:
       - 'https://www.youtube.com/watch?v=eoP2diMYjW8'
-  - title: 'Marvel Super-Search: Comment j''ai scrappé les superhéros Marvel'
-    extract: >
+  - title: "Marvel Super-Search: Comment j'ai scrappé les superhéros Marvel"
+    extract: |
       Je vous propose de faire un REX sur un side-project récent:
       https://pixelastic.github.io/marvel/
 
@@ -74,7 +74,7 @@ talks:
       - 'https://pixelastic.github.io/marvel/'
     videos: []
   - title: Please Welcome Angular 2
-    extract: >
+    extract: |
       Tu as vaguement entendu parler d'une version 2 d'Angular ? Mais tu n'as eu
       le temps de t'y mettre ? Ce talk t'expliquera ce qu'il faut savoir pour
       débuter une application Web en Angular 2. Nous parlerons toolings,
@@ -89,7 +89,7 @@ talks:
       - 'https://angular.io/'
     videos: []
   - title: 'Retour vers le Futur avec React, Redux et Immutable'
-    extract: >
+    extract: |
       Redux a repris et amélioré les principes de Flux, et se marie à merveille
       avec React. Il permet de mettre en place simplement des composants
       fonctionnels (et, avec l'aide d'ImmutableJS, la programmation fonctionnel

--- a/content/meetups/2016-05-25.md
+++ b/content/meetups/2016-05-25.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/231093076/
 talks:
   - title: 'FLIP : First Last Invert Play'
-    extract: >
+    extract: |
       Comment faire des Layout Animations sans faire de Layout Animation ?
 
 
@@ -48,7 +48,7 @@ talks:
     links: []
     videos: []
   - title: myNodeModule.mjs?
-    extract: >
+    extract: |
       Ce lightning talk a vocation à présenter le choix important auquel fait
       face la communauté node aujourd'hui : Va-t-il être nécessaire d'adopter
       une nouvelle extension, .mjs, pour pouvoir utiliser nativement les modules
@@ -63,7 +63,7 @@ talks:
       - 'https://github.com/nodejs/node-eps/blob/master/002-es6-modules.md'
     videos: []
   - title: Faire du bruit avec Pizzicato JS
-    extract: >-
+    extract: |-
       Web audio ouvre plein de possibilités pour enrichir les applis avec des
       effets de son ou même pour créer de la musique. Par contre, grimper la
       courbe d'apprentissage du web audio n'est pas simple.

--- a/content/meetups/2016-06-29.md
+++ b/content/meetups/2016-06-29.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/232103659/
 talks:
   - title: 'La Citizen UX à Paris, parallèle entre la ville Hausmanienne et le Web'
-    extract: >-
+    extract: |-
       Le web a mis en place des règles de vie en communauté, a fait des choix
       d'architecture et de nouvelles features sur la base de contraintes
       analogues à celles d'Haussmann en 1853. Très visuel, un framework de
@@ -24,7 +24,7 @@ talks:
     links: []
     videos: []
   - title: La philosophie Elm en Javascript
-    extract: >+
+    extract: |+
       Les applications web sont de plus en plus évoluées, et donc de plus en
       plus difficiles à écrire et à maintenir. De plus, le langage à utiliser
       est presque forcément Javascript, qui n'a pas été conçu à l'origine pour
@@ -49,7 +49,7 @@ talks:
     links: []
     videos: []
   - title: 'Trello, Kanban et Cycle.js'
-    extract: >+
+    extract: |+
       Introduction au Functional Reactive Programming avec Cycle.js / Rx.js sur
       l’exemple d’un side project open-source : Trello Kanban Analysis Tool
       (https://github.com/nicoespeon/trello-kanban-analysis-tool).

--- a/content/meetups/2016-10-05.md
+++ b/content/meetups/2016-10-05.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/233760264/
 talks:
   - title: JavaScript & les jeux vidéos cross-plateformes
-    extract: >
+    extract: |
       C++, Java ou C# sont les langages rois de la création de jeux, mais de
       plus en plus de libraries et frameworks JavaScript sont disponibles,
       notamment depuis l'arrivée de WebGL !
@@ -36,7 +36,7 @@ talks:
     links: []
     videos: []
   - title: UI Animation in React
-    extract: >-
+    extract: |-
       Je fais un tour des différentes solutions qui existent à l'heure actuelle
       pour l'animations des composants pendant leur cycle de vie (mount,
       unmount, etc…) :

--- a/content/meetups/2016-10-26.md
+++ b/content/meetups/2016-10-26.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/235013838/
 talks:
   - title: A Journey toward better style
-    extract: >-
+    extract: |-
       Je veux exposer les challenges / problèmes / solutions que j'ai abordés
       lors de la construction d'éléments visuels isolés et composables à travers
       différents projets. Cependant, je veux me concentrer sur un projet open
@@ -40,7 +40,7 @@ talks:
     links: []
     videos: []
   - title: Votre première progressive web app
-    extract: >-
+    extract: |-
       Le monde du web évolue et la barrière entre web mobile et application
       mobile devient de plus en plus fine.
 
@@ -69,7 +69,7 @@ talks:
     links: []
     videos: []
   - title: Tester des composants React avec des snapshots
-    extract: >-
+    extract: |-
       Le but est d'apprendre qu'il est possible de tester des composants React
       de manière unitaire, donc extrêmement rapide.
 
@@ -93,7 +93,7 @@ talks:
       - 'https://github.com/tcheymol/react-component-snapshots'
     videos: []
   - title: Pourquoi vous devriez tester VueJS en v2
-    extract: >-
+    extract: |-
       La v2 de VueJS est sortie. Et la communauté adhère, affichant déjà plus de
       30000 stars sur github !
 

--- a/content/meetups/2016-12-03.md
+++ b/content/meetups/2016-12-03.md
@@ -6,7 +6,7 @@ sponsors: [dotJS]
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/235413985/
 talks:
   - title: 'DocSearch: The easiest way to add search to your documentation'
-    extract: >-
+    extract: |-
       Everytime you discover a new framework or library, you have to spend time
       in its documentation. If you've recently used React, React Native, Eslint
       or Yarn you might have noticed that they have an ultra fast and relevant
@@ -29,7 +29,7 @@ talks:
     links: []
     videos: []
   - title: Five minutes before prod
-    extract: >-
+    extract: |-
       This talk is about how we build & deploy a complex AngularJS/TypeScript
       app in production at Aircall.
 
@@ -60,8 +60,8 @@ talks:
         https://speakerdeck.com/stefanjudis/unicode-javascript-and-the-emoji-family
     links: []
     videos: []
-  - title: 'Stop wasting your users'' time, make them happy'
-    extract: >-
+  - title: "Stop wasting your users' time, make them happy"
+    extract: |-
       You're in the metro and want to load your favorite web app. After waiting
       10 seconds without any response from the app, you close your browser,
       angry. How can you avoid this classic user story?
@@ -80,7 +80,7 @@ talks:
     links: []
     videos: []
   - title: Understanding REST APIs in 5 Simple Steps
-    extract: >-
+    extract: |-
       As APIs have become increasingly more important and popular in usage in
       the past few years in web development, it is important to understand the
       basics of what they are and why to use them.
@@ -99,7 +99,7 @@ talks:
     links: []
     videos: []
   - title: Why I stopped using npm
-    extract: >-
+    extract: |-
       I'll explain why you have to start using Yarn instead of npm, how to do
       it, and what to keep in mind.
     authors:

--- a/content/meetups/2017-01-25.md
+++ b/content/meetups/2017-01-25.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/237040978/
 talks:
   - title: JavaScript et DOM dans vos terminaux
-    extract: >
+    extract: |
       Cela fait maintenant quelques mois que je bosse sur la seconde itération
       d'une bibliothèque de mon cru permettant de faire du rendu sur terminaux
       via une API DOM et CSS-like. Une petite présentation pour en montrer les
@@ -22,7 +22,7 @@ talks:
       - 'https://github.com/manaflair/mylittledom'
     videos: []
   - title: 'Real-time applications with GraphQL, Node.js and MQTT'
-    extract: >
+    extract: |
       GraphQL is known as supporting queries and mutations, and now it supports
       subscriptions as well. With subscriptions clients can get updates pushed
       from the server when data they care about changes. In this talk, the
@@ -39,7 +39,7 @@ talks:
       - 'https://github.com/JacopoDaeli/realtime-graphql'
     videos: []
   - title: Comment bien choisir son associé business ?
-    extract: >
+    extract: |
       Après avoir monté breaz.io (racheté par Hired), j'aimerais partager mes
       retours d'expérience pour réussir à identifier les bons profils business
       avec lesquels s'associer.
@@ -64,8 +64,8 @@ talks:
     slides: []
     links: []
     videos: []
-  - title: 'Génération dynamiques d''applications avec React, Redux et Cordova'
-    extract: >
+  - title: "Génération dynamiques d'applications avec React, Redux et Cordova"
+    extract: |
       Pour ses clients, One2Team fournit des apps sur-mesures qui sont conçues
       pour répondre à un besoin précis identifié sur le terrain : préparer son
       daily Scrum, faire un compte rendu de visite de site technique, ...

--- a/content/meetups/2017-05-31.md
+++ b/content/meetups/2017-05-31.md
@@ -2,11 +2,11 @@
 edition: '65'
 date: '2017-05-31'
 host: Zenika
-sponsors: ["Freelance Academy"]
+sponsors: ['Freelance Academy']
 meetupLink: null
 talks:
   - title: Dispersive
-    extract: >
+    extract: |
       Dispersive est un framework de mise a jour de store inspiré par flux. Sa
       particularité est que sa structure est définie comme un ORM. Un store
       unique est défini par des relations entre différents models.

--- a/content/meetups/2017-06-28.md
+++ b/content/meetups/2017-06-28.md
@@ -16,7 +16,7 @@ talks:
     links: []
     videos: []
   - title: Devops 101
-    extract: >
+    extract: |
       Les « dev » et les « ops » se livrent une guerre depuis que le monde est
       monde ! Le clan « dev » n'arrive plus à comprendre les rouages de ce
       terrible conflit. Il est temps de rétablir la vérité vrai
@@ -38,7 +38,7 @@ talks:
     links: []
     videos: []
   - title: 'Je ne suis pas indépendant, mais je travaille à la maison'
-    extract: >
+    extract: |
       On trouve beaucoup d’articles de blog sur le « Remote work », moins sur le
       télétravail. Si les entreprises en France s’ouvrent petit à petit, journée
       par journée au télétravail, le full remote est moins courant. Pourtant,

--- a/content/meetups/2017-09-27.md
+++ b/content/meetups/2017-09-27.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: https://www.meetup.com/fr-FR/Paris-js/events/243414540/
 talks:
   - title: NodeJs Event Loop
-    extract: >-
+    extract: |-
       Suite à une récente key note de Bert Belder concernant l'event loop de
       NodeJs je peux proposer de revenir sur son intervention et plus
       généralement sur le fonctionnement de l'event loop + libUv qui sont au
@@ -23,7 +23,7 @@ talks:
     links: []
     videos: []
   - title: Reason
-    extract: >-
+    extract: |-
       La next step de JS: Pourquoi JS est insuffisant. Comment régler le
       problème à l'échelle de JS. Comment VRAIMENT régler le problème.
     authors:
@@ -36,7 +36,7 @@ talks:
   - title: >-
       Time for IntersectionObserver - a performant and easy to use alternative
       to scroll handlers for in view detection
-    extract: >-
+    extract: |-
       Lazy loading content, tracking impression, animation triggers
 
       - for many years we have utilised scroll handlers to detect when

--- a/content/meetups/2017-10-25.md
+++ b/content/meetups/2017-10-25.md
@@ -17,7 +17,7 @@ talks:
     videos:
       - 'https://youtu.be/XYtmT82M42o?t=1h2m34s'
   - title: 'JS, jeux et animation : the flash nostalgia'
-    extract: >
+    extract: |
       Par le biais d'un petit retour d'expérience sur trois jeux que nous venons
       de créer pour le web, je vous présente quelques bibliothèques js dédiées
       au front et notamment :
@@ -40,7 +40,7 @@ talks:
     videos:
       - 'https://youtu.be/XYtmT82M42o?t=7m13s'
   - title: Ne laissez pas votre state devenir un monstre informe avec Immutable.js
-    extract: >
+    extract: |
       Vos reducers ne ressemblent plus à rien, tant ils sont bourrés de
       Object.assign ou de spread operators ? Vous vous arrachez les cheveux à
       débusquer une mutation inopinée de votre state ?

--- a/content/meetups/2017-11-29.md
+++ b/content/meetups/2017-11-29.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/244179664/'
 talks:
   - title: Feel the Glimmer
-    extract: >
+    extract: |
       Glimmer.js was announced at EmberConf 2017 and makes Ember.js' hyper-fast rendering engine Glimmer available to everyone as a lightweight UI component library for the web. It also leads the way into the future of the Ember.js framework itself.
 
       In this talk I'll dive deep into the internals of the Glimmer VM, show how it's powers can be leveraged via Glimmer.js and explain what benefits TypeScript that both are written in provides. I'll end with a look into the future and explain how Glimmer.js and Ember.js will form an ecosystem that apps of all sizes can flourish in.
@@ -18,7 +18,7 @@ talks:
     links: []
     videos: []
   - title: 'Static websites also get hacked: A security primer'
-    extract: >
+    extract: |
       While static websites lack a lot of the security issues found in dynamically generated webapps, they still face plenty of threats. Cross-site scripting, clickjacking, framebusting, referer leakage, and man in the middle attacks all sound awfully nasty, but what are they and why do we need to worry about them? Looking at realistic examples, I explain these kinds of attacks, and outline the tools that modern browsers provide to combat them.
     authors:
       - name: Alexander Ottenhoff
@@ -28,7 +28,7 @@ talks:
     links: []
     videos: []
   - title: 'Coffee.js - How I hacked my coffee machine using JavaScript'
-    extract: >
+    extract: |
       Home automation should make our lives easier, but my Echo can't make me coffee. As a developer who turns caffeine into code, this is unacceptable. The only thing to do was use code to make coffee.
 
       This is the story of how I hacked an API onto my coffee machine. We'll look at why you would chose JavaScript to hack the machine, what you need to do to take control of a coffee machine (without too many shocks), and what other things we can do with JavaScript and hardware. As we wrap up with a look at what's next for my project, you'll be dreaming of the gadgets in your house that you can't wait to rip open and give an API.
@@ -41,4 +41,3 @@ talks:
     links: []
     videos: []
 ---
-

--- a/content/meetups/2018-01-31.md
+++ b/content/meetups/2018-01-31.md
@@ -6,8 +6,8 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/246746052/'
 talks:
   - title: 'You’re probably making an api client'
-    extract: >
-        Going through the secrets that make Algolia's JavaScript API fast in a hands-on way.
+    extract: |
+      Going through the secrets that make Algolia's JavaScript API fast in a hands-on way.
     authors:
       - name: Haroen
         url: 'https://twitter.com/haroenv'
@@ -16,22 +16,22 @@ talks:
     links: ['https://haroen.me/presentations/en/api-client/']
     videos: ['https://twitter.com/mauriz/status/958768177252618240']
   - title: 'Introduction à GraphQL'
-    extract: >
-        Cette talk est une intro à l'ecosystème GraphQL. J'y présente ce qu'est graphQL, les bases du language et des queries. J'explique le type system graphQL et ces avantages.
+    extract: |
+      Cette talk est une intro à l'ecosystème GraphQL. J'y présente ce qu'est graphQL, les bases du language et des queries. J'explique le type system graphQL et ces avantages.
 
-        Je fais une démonstration d'un application faites en graphQL et je décris les librairies et outils pour commencer à faire du graphQL côté server ou client.
+      Je fais une démonstration d'un application faites en graphQL et je décris les librairies et outils pour commencer à faire du graphQL côté server ou client.
 
-        A la fin je fais une démonstration d'une application graphQL et un code walkthrough.
+      A la fin je fais une démonstration d'une application graphQL et un code walkthrough.
     authors:
       - name: Alexandre
         url: ''
         avatar: ''
     slides:
-        - 'https://spectacle-boilerplate-lzkrjostgk.now.sh/'
+      - 'https://spectacle-boilerplate-lzkrjostgk.now.sh/'
     links: []
     videos: ['https://twitter.com/mauriz/status/958768177252618240']
   - title: 'Jouer avec async_hooks en Node.js'
-    extract: >
+    extract: |
       Async_hook api is probably one of the coolest addition to recent Node.js. Why ? Also, What can we build with it ?
     authors:
       - name: Vladimir

--- a/content/meetups/2018-02-28.md
+++ b/content/meetups/2018-02-28.md
@@ -6,15 +6,15 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/247736771/'
 talks:
   - title: '5 idées reçues sur react-native'
-    extract: >
-        En tant que développeur react-native, je fais souvent face aux mêmes remarques :
-        - "Ce n'est pas du natif, du coup c'est moins fluide, non ?"
-        - "Je ne suis pas sûr de pouvoir faire [insérer votre feature ici] avec react-native"
-        - "Ça vient de sortir, dans un an c'est mort !"
-        - "Est-ce que c'est maintenable sur le long terme ?"
-        - "Mais ce n'est pas super dur de recruter des devs pour faire du react-native ?"
+    extract: |
+      En tant que développeur react-native, je fais souvent face aux mêmes remarques :
+      - "Ce n'est pas du natif, du coup c'est moins fluide, non ?"
+      - "Je ne suis pas sûr de pouvoir faire [insérer votre feature ici] avec react-native"
+      - "Ça vient de sortir, dans un an c'est mort !"
+      - "Est-ce que c'est maintenable sur le long terme ?"
+      - "Mais ce n'est pas super dur de recruter des devs pour faire du react-native ?"
 
-        Je vous propose de faire une introduction à react-native en reprenant ces points un par un.
+      Je vous propose de faire une introduction à react-native en reprenant ces points un par un.
     authors:
       - name: Nicolas
         url: 'https://twitter.com/nhacsam_'
@@ -23,15 +23,15 @@ talks:
     links: []
     videos: ['https://www.pscp.tv/mauriz1/1djGXdmaDnNGZ?t=30m30s']
   - title: 'React Navigation'
-    extract: >
-        Présentation de la libraire React Navigation, très utilisée dans les projets React-Native.
-        Pourquoi la navigation est différente sur mobile par rapport au web ? Pourquoi on utilise pas juste react-router ? Comment s'y retrouver parmi toutes les libs de navigation (historique des solutions + explication différences techniques) ? Comment faire des différences sur la nav entre Android et iOS ? Et présentation théorique et pratique de React Navigation avec retour d'XP avec une app sur store iOS et Android.
+    extract: |
+      Présentation de la libraire React Navigation, très utilisée dans les projets React-Native.
+      Pourquoi la navigation est différente sur mobile par rapport au web ? Pourquoi on utilise pas juste react-router ? Comment s'y retrouver parmi toutes les libs de navigation (historique des solutions + explication différences techniques) ? Comment faire des différences sur la nav entre Android et iOS ? Et présentation théorique et pratique de React Navigation avec retour d'XP avec une app sur store iOS et Android.
     authors:
       - name: Freddy Harris
         url: 'https://twitter.com/harrisfreddy'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/harrisfreddy&amps;embed=image.url'
     slides:
-        - 'http://react-navigation-keynote.surge.sh/'
+      - 'http://react-navigation-keynote.surge.sh/'
     links: []
     videos: ['https://www.pscp.tv/mauriz1/1djGXdmaDnNGZ?t=57m00s']
 ---

--- a/content/meetups/2018-03-28.md
+++ b/content/meetups/2018-03-28.md
@@ -6,44 +6,44 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/248802121/'
 talks:
   - title: 'Making search on Yarnpkg.com'
-    extract: >
-        As you might have noticed, yarnpkg.com has search and detail pages now. I (and other team members at Algolia: Sylvain Utard, Vincent Voyer, Kevin Granger) worked on this as part of my internship at Algolia.
+    extract: |
+      As you might have noticed, yarnpkg.com has search and detail pages now. I (and other team members at Algolia: Sylvain Utard, Vincent Voyer, Kevin Granger) worked on this as part of my internship at Algolia.
 
-        I'll talk about how working together with a Facebook team went, adding React to an otherwise static website, Netlify rewrites, i18n and all kinds of other things that come into play when making a site like this.
+      I'll talk about how working together with a Facebook team went, adding React to an otherwise static website, Netlify rewrites, i18n and all kinds of other things that come into play when making a site like this.
     authors:
       - name: Haroen
         url: 'https://twitter.com/haroenv'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/haroenv&amps;embed=image.url'
-    slides: 
-        - 'https://haroen.me/presentations/en/yarn-search/'
+    slides:
+      - 'https://haroen.me/presentations/en/yarn-search/'
     links: []
-    videos: 
-        - 'https://youtu.be/ankmADwX7CU?t=30m2s'
+    videos:
+      - 'https://youtu.be/ankmADwX7CU?t=30m2s'
   - title: 'Expo: La petite révolution dans React Native'
-    extract: >
-        De nombreux développeurs ont du mal à installer et à configurer les dépendances actuelles de React Native, en particulier pour Android. Avec Expo, il n'est pas nécessaire d'utiliser Xcode ou Android Studio, et vous pouvez développer votre application iOS sur Linux ou Windows.
+    extract: |
+      De nombreux développeurs ont du mal à installer et à configurer les dépendances actuelles de React Native, en particulier pour Android. Avec Expo, il n'est pas nécessaire d'utiliser Xcode ou Android Studio, et vous pouvez développer votre application iOS sur Linux ou Windows.
     authors:
       - name: Jean-Claude Pratt
-        url: 
-        avatar: 
+        url:
+        avatar:
     slides: []
     links: []
-    videos: 
-        - 'https://youtu.be/ankmADwX7CU?t=49m32s'
+    videos:
+      - 'https://youtu.be/ankmADwX7CU?t=49m32s'
   - title: 'Third-party hell'
-    extract: >
-        Retour d'expérience sur le développement de widgets third-party, dans le désordre:
-        - Petit tour des limitations inhérentes au third-party
-        - Le first-party est un environment hostile
-        - Stratégies possibles, pour et contre de chaque
-        - Comment concevoir l'expérience la plus solide et naturelle possible niveau UX/UI avec toutes ces contraintes
+    extract: |
+      Retour d'expérience sur le développement de widgets third-party, dans le désordre:
+      - Petit tour des limitations inhérentes au third-party
+      - Le first-party est un environment hostile
+      - Stratégies possibles, pour et contre de chaque
+      - Comment concevoir l'expérience la plus solide et naturelle possible niveau UX/UI avec toutes ces contraintes
     authors:
       - name: Matthias Le Brun
         url: 'https://twitter.com/bloodyowl'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/bloodyowl&amps;embed=image.url'
-    slides: 
-        - https://speakerdeck.com/bloodyowl/third-party-hell
+    slides:
+      - https://speakerdeck.com/bloodyowl/third-party-hell
     links: []
-    videos: 
-        - 'https://youtu.be/ankmADwX7CU?t=1m13s'
+    videos:
+      - 'https://youtu.be/ankmADwX7CU?t=1m13s'
 ---

--- a/content/meetups/2018-04-25.md
+++ b/content/meetups/2018-04-25.md
@@ -6,13 +6,13 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/249735887/'
 talks:
   - title: 'Event Loop chapter 2'
-    extract: >
-        La magie de NodeJs pour gérer les I/O asynchrone a un nom : l'event loop.
-        Après un premier talk accès sur les erreurs de conception liées à cette event loop c'est le moment d'expliquer certaines de ses subtilités :
+    extract: |
+      La magie de NodeJs pour gérer les I/O asynchrone a un nom : l'event loop.
+      Après un premier talk accès sur les erreurs de conception liées à cette event loop c'est le moment d'expliquer certaines de ses subtilités :
 
-        setImmediate vs process.nextTick
-        les librairies évènementielles derrière NodeJs
-        monitorer l'event-loop
+      setImmediate vs process.nextTick
+      les librairies évènementielles derrière NodeJs
+      monitorer l'event-loop
     authors:
       - name: Vincent
         url: 'https://twitter.com/Vince_Vallet'
@@ -21,29 +21,29 @@ talks:
     links: []
     videos: []
   - title: "3 semaines pour former un dev, C'est possible !"
-    extract: >
-        Lors des 2 derniers mois, 10 nouveaux développeurs sont arrivés chez BAM. Certains avaient déjà fait beaucoup de dev, d'autres sortent juste d'école. Cela fait du monde à former sur nos technos et notre façon de coder !
+    extract: |
+      Lors des 2 derniers mois, 10 nouveaux développeurs sont arrivés chez BAM. Certains avaient déjà fait beaucoup de dev, d'autres sortent juste d'école. Cela fait du monde à former sur nos technos et notre façon de coder !
 
-        Pour autant, même avec 20% de nouveaux développeurs notre objectif reste le même : Être des experts en React-native.
+      Pour autant, même avec 20% de nouveaux développeurs notre objectif reste le même : Être des experts en React-native.
 
-        Notre process de formation était un peu flou et certaines équipes avaient des difficultés à intégrer un nouveau. Grâce à des techniques d'amélioration continue, j'ai pu consolider notre formation et désormais 100% des dev se sentent efficaces quand ils rejoignent leur premier projet. Ce sont ces apprentissages que je veux vous partager.
+      Notre process de formation était un peu flou et certaines équipes avaient des difficultés à intégrer un nouveau. Grâce à des techniques d'amélioration continue, j'ai pu consolider notre formation et désormais 100% des dev se sentent efficaces quand ils rejoignent leur premier projet. Ce sont ces apprentissages que je veux vous partager.
     authors:
       - name: Nicolas
         url: 'https://twitter.com/nhacsam_'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/nhacsam_&amps;embed=image.url'
-    slides: 
-        - https://t.co/kiEUSol7oq
+    slides:
+      - https://t.co/kiEUSol7oq
     links: []
-    videos: 
+    videos:
   - title: 'Déployer un package sur npm de manière automatisée et en respectant semver avec semantic-release'
-    extract: >
-        Semver est un contrat entre l'auteur d'un package et ses utilisateurs. Si celui-ci n'est pas respecté, l'impact peut être énorme pour ces derniers (application cassée après une mise à jour mineure, notamment). Comment faire, en tant qu'auteur, pour s'assurer qu'on respecte ce contrat ? Présentation de semantic-release, un outil qui a pour but de régler ce problème avec une grosse cuillère d'automatisation et une pincée de convention.
+    extract: |
+      Semver est un contrat entre l'auteur d'un package et ses utilisateurs. Si celui-ci n'est pas respecté, l'impact peut être énorme pour ces derniers (application cassée après une mise à jour mineure, notamment). Comment faire, en tant qu'auteur, pour s'assurer qu'on respecte ce contrat ? Présentation de semantic-release, un outil qui a pour but de régler ce problème avec une grosse cuillère d'automatisation et une pincée de convention.
     authors:
       - name: Cyrille
         url: 'https://twitter.com/JesmoDrazik'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/JesmoDrazik&amps;embed=image.url'
-    slides: 
-        - https://t.co/WGqHomHj3d
+    slides:
+      - https://t.co/WGqHomHj3d
     links: []
-    videos: 
+    videos:
 ---

--- a/content/meetups/2018-05-30.md
+++ b/content/meetups/2018-05-30.md
@@ -6,46 +6,46 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/250133834/'
 talks:
   - title: 'Why Automated Testing is cool, and where to start'
-    extract: >
-        - Why testing is good practice
-        - Why testing is cool
-        - Unit testing: why + how + example
-        - Integration testing: why + how + example
-        - Acceptance/e2e/API testing: why + how + examples
+    extract: |
+      - Why testing is good practice
+      - Why testing is cool
+      - Unit testing: why + how + example
+      - Integration testing: why + how + example
+      - Acceptance/e2e/API testing: why + how + examples
 
-        Examples will be based on experience with Algolia's Crawler (Distributed system built on Node.js), Openwhyd (Ex "legacy" startup product --> open-source project) and Next Step for Trello (Google Chrome extension, open-source).
+      Examples will be based on experience with Algolia's Crawler (Distributed system built on Node.js), Openwhyd (Ex "legacy" startup product --> open-source project) and Next Step for Trello (Google Chrome extension, open-source).
 
-        Tech stack: Node.js, Docker, Jest (incl. snapshots), Webdriver.io + Selenium.
+      Tech stack: Node.js, Docker, Jest (incl. snapshots), Webdriver.io + Selenium.
     authors:
       - name: 'Adrien Joly'
         url: 'http://twitter.com/adrienjoly'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/adrienjoly&amps;embed=image.url'
     slides:
-        - 'http://adrienjoly.com/slides/testing'
+      - 'http://adrienjoly.com/slides/testing'
     links:
-        - 'https://github.com/adrienjoly/adrienjoly.github.com/tree/master/slides/testing/sample-tests'
+      - 'https://github.com/adrienjoly/adrienjoly.github.com/tree/master/slides/testing/sample-tests'
     videos:
-        - 'https://youtu.be/LQry0d1kb_o?t=11m43s'
+      - 'https://youtu.be/LQry0d1kb_o?t=11m43s'
   - title: 'Modern services communication with gRPC'
-    extract: >
-        Une présentation de gRPC + protobuf pour architecturer ses microservices, avec une petite démo en nodeJS et une petit clin d'oeil à GraphQL
+    extract: |
+      Une présentation de gRPC + protobuf pour architecturer ses microservices, avec une petite démo en nodeJS et une petit clin d'oeil à GraphQL
     authors:
       - name: 'Mathieu'
         url: 'http://twitter.com/zoontek'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/zoontek&amps;embed=image.url'
     slides:
-        - 'https://speakerdeck.com/zoontek/manage-microservices-like-a-chef'
+      - 'https://speakerdeck.com/zoontek/manage-microservices-like-a-chef'
     links: []
     videos:
-        - 'https://youtu.be/LQry0d1kb_o?t=40m10s'
+      - 'https://youtu.be/LQry0d1kb_o?t=40m10s'
   - title: 'The amazing tale of Internet S01E01: Pilot'
-    extract: >
-        Amérique, début du 20e siècle.
-        AT&T domine le marché de la téléphonie et se rapproche de Western Electric.
-        Ensemble, ils fusionnent leurs départements de recherche et créent les Bell Labs.
-        De l'autre côté de l'Atlantique, Sputnik, le premier satellite, est lancé en 1957, symbole de l'entrée dans l'ère spatiale.
-        Un jeune ingénieur, Ken Thompson, rejoint les Bell Labs en 1966 et va changer le cours de l'histoire.
-        #CERN #JS #AppletJava #Netscape #BrowserWars
+    extract: |
+      Amérique, début du 20e siècle.
+      AT&T domine le marché de la téléphonie et se rapproche de Western Electric.
+      Ensemble, ils fusionnent leurs départements de recherche et créent les Bell Labs.
+      De l'autre côté de l'Atlantique, Sputnik, le premier satellite, est lancé en 1957, symbole de l'entrée dans l'ère spatiale.
+      Un jeune ingénieur, Ken Thompson, rejoint les Bell Labs en 1966 et va changer le cours de l'histoire.
+      #CERN #JS #AppletJava #Netscape #BrowserWars
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
@@ -53,5 +53,5 @@ talks:
     slides: []
     links: []
     videos:
-        - 'https://youtu.be/LQry0d1kb_o?t=59m00s'
+      - 'https://youtu.be/LQry0d1kb_o?t=59m00s'
 ---

--- a/content/meetups/2018-06-27.md
+++ b/content/meetups/2018-06-27.md
@@ -6,13 +6,13 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/251583359/'
 talks:
   - title: 'The amazing tale of Internet S01E02: The Dynamic Web era'
-    extract: >
-        An 2000, 368 000 000 d'ordinateurs connectés.
-        Les beaux jours de l'ASP, PHP, et l'arrivée de J2PE (ancêtre de JEE) marquent l'entrée dans le web dynamique. Javascript est synonyme de langage de bidouilleurs, lent, et non exempt de failles de sécurité.
-        En 2006, une fissure commence à apparaitre.
-        Le Wap prend sa retraite, les netbooks et Smartphones arrivent : une transformation doit s'opérer.
-        Un jour, Google annonce son navigateur Chrome, cachant un moteur qui va changer la donne.
-        #DynamicWeb #W3C #HTML5 #WebFrameworks #V8
+    extract: |
+      An 2000, 368 000 000 d'ordinateurs connectés.
+      Les beaux jours de l'ASP, PHP, et l'arrivée de J2PE (ancêtre de JEE) marquent l'entrée dans le web dynamique. Javascript est synonyme de langage de bidouilleurs, lent, et non exempt de failles de sécurité.
+      En 2006, une fissure commence à apparaitre.
+      Le Wap prend sa retraite, les netbooks et Smartphones arrivent : une transformation doit s'opérer.
+      Un jour, Google annonce son navigateur Chrome, cachant un moteur qui va changer la donne.
+      #DynamicWeb #W3C #HTML5 #WebFrameworks #V8
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
@@ -20,36 +20,36 @@ talks:
     slides: []
     links: []
     videos:
-        - 'https://youtu.be/xR4y5zNokc0?t=24m35s'
+      - 'https://youtu.be/xR4y5zNokc0?t=24m35s'
   - title: 'Machine learning <3 JS : rendez votre navigateur web intelligent'
-    extract: >
-        Faire du machine learning n'est plus seulement réservé aux charmeurs de serpents (pythonistas) ou à ceux ayant accès à des machines puissantes. Dans le cadre du projet PAIR, l'équipe Brain de Google sortait la librairie deeplearn.js qui a depuis lors évolué pour laisser place à TensorFlow.js. Tensorflow.js se base sur WebGL et permet entre autres de construire et d'entrainer des modèles de données dans le navigateur "from scratch" ou en utilisant des techniques telles que le "transfer learning".
+    extract: |
+      Faire du machine learning n'est plus seulement réservé aux charmeurs de serpents (pythonistas) ou à ceux ayant accès à des machines puissantes. Dans le cadre du projet PAIR, l'équipe Brain de Google sortait la librairie deeplearn.js qui a depuis lors évolué pour laisser place à TensorFlow.js. Tensorflow.js se base sur WebGL et permet entre autres de construire et d'entrainer des modèles de données dans le navigateur "from scratch" ou en utilisant des techniques telles que le "transfer learning".
 
-        Je vous expliquerai durant ce talk comment nous avons développé une PWA "intélligente" en utilisant du machine learning.
+      Je vous expliquerai durant ce talk comment nous avons développé une PWA "intélligente" en utilisant du machine learning.
     authors:
       - name: 'Anta'
         url: 'https://twitter.com/aidaraanta'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/aidaraanta&amps;embed=image.url'
     slides:
-        - 'https://slides.com/antamb/deep-shit-aka-deep-learning-dans-le-navigateur#/'
+      - 'https://slides.com/antamb/deep-shit-aka-deep-learning-dans-le-navigateur#/'
     links: []
     videos:
-        - 'https://youtu.be/xR4y5zNokc0?t=44m29s'
+      - 'https://youtu.be/xR4y5zNokc0?t=44m29s'
   - title: 'Deux fans de React amenés à faire de l’Angular et ce qu’ils en ont appris'
-    extract: >
-        Après avoir travaillé avec React pendant plusieurs années, la providence nous a rassemblé sur le même projet Angular 4 pendant lequel nous avons pu découvrir ses joies et ses peines.
+    extract: |
+      Après avoir travaillé avec React pendant plusieurs années, la providence nous a rassemblé sur le même projet Angular 4 pendant lequel nous avons pu découvrir ses joies et ses peines.
 
-        Venez si vous êtes intéressés de découvrir la vie au jour le jour de développeurs React forcés par le destin de travailler avec Angular.
-        Venez si vous voulez savoir en quoi ça n’était pas si mal.
+      Venez si vous êtes intéressés de découvrir la vie au jour le jour de développeurs React forcés par le destin de travailler avec Angular.
+      Venez si vous voulez savoir en quoi ça n’était pas si mal.
 
-        Enfin, vous aurez la chance d’apprendre la réponse à la grande question : Quel framework dois-je choisir pour ma prochaine application front, le tout basé sur un retour d'expérience.
+      Enfin, vous aurez la chance d’apprendre la réponse à la grande question : Quel framework dois-je choisir pour ma prochaine application front, le tout basé sur un retour d'expérience.
     authors:
       - name: 'Loïc Carbonne'
         url: 'https://twitter.com/loiccarbonne'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/loiccarbonne&amps;embed=image.url'
     slides:
-        - 'https://slides.com/loiccarbonne/deck-5-3#/'
+      - 'https://slides.com/loiccarbonne/deck-5-3#/'
     links: []
     videos:
-        - 'https://youtu.be/xR4y5zNokc0?t=1h16m34s'
+      - 'https://youtu.be/xR4y5zNokc0?t=1h16m34s'
 ---

--- a/content/meetups/2018-08-29.md
+++ b/content/meetups/2018-08-29.md
@@ -6,39 +6,39 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/251642385/'
 talks:
   - title: 'Build Advanced Search Experiences with a Custom Query Language'
-    extract: >
-        How many checkboxes can you add before your customer just gives up? When working with large, flexible data structures, click-based interfaces quickly become cumbersome; worse, text-based search is often too imprecise. In this talk, I’ll explain how to create a custom query language that allows for complex searches in just a few keystrokes, and how to integrate it seamlessly into a web interface.
+    extract: |
+      How many checkboxes can you add before your customer just gives up? When working with large, flexible data structures, click-based interfaces quickly become cumbersome; worse, text-based search is often too imprecise. In this talk, I’ll explain how to create a custom query language that allows for complex searches in just a few keystrokes, and how to integrate it seamlessly into a web interface.
 
-        This would be an updated version of the talk I gave at JSConf.eu: https://www.youtube.com/watch?v=P2yB_iEJXyI
+      This would be an updated version of the talk I gave at JSConf.eu: https://www.youtube.com/watch?v=P2yB_iEJXyI
     authors:
       - name: 'Adrien Trauth'
         url: 'http://twitter.com/nioufe'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/nioufe&amps;embed=image.url'
     slides:
-        - http://dtdg.co/advanced-search
+      - http://dtdg.co/advanced-search
     links: []
     videos:
-        - 'https://youtu.be/x8pErCJ1bAU?t=7m30s'
+      - 'https://youtu.be/x8pErCJ1bAU?t=7m30s'
   - title: 'Delivering Fast and Beautiful Images and Video'
-    extract: >
-        The average website page weight is 50% images and 25% video. As the images and videos delivered to mobile devices get larger and larger, the load time of websites gets slower and slower. Further complicating matters, there are thousands of screens and devices with varying resolutions and CPU power that receive this content. In this talk, we’ll examine strategies to send the perfect image or video to every device, ensuring a fast, beautiful rendering of your content. We’ll look at how to test our content, and describe responsive images, delivering progressive images, and finally optimizing all of this content for fast delivery to each screen. Attendees will walk away with a better understanding of how to efficiently deliver beautiful images to every device that accesses their content.
+    extract: |
+      The average website page weight is 50% images and 25% video. As the images and videos delivered to mobile devices get larger and larger, the load time of websites gets slower and slower. Further complicating matters, there are thousands of screens and devices with varying resolutions and CPU power that receive this content. In this talk, we’ll examine strategies to send the perfect image or video to every device, ensuring a fast, beautiful rendering of your content. We’ll look at how to test our content, and describe responsive images, delivering progressive images, and finally optimizing all of this content for fast delivery to each screen. Attendees will walk away with a better understanding of how to efficiently deliver beautiful images to every device that accesses their content.
     authors:
       - name: 'Doug Sillars'
         url: 'http://twitter.com/dougsillars'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/dougsillars&amps;embed=image.url'
     slides:
-        - https://www.slideshare.net/dougsillars/
+      - https://www.slideshare.net/dougsillars/
     links: []
     videos:
-        - 'https://youtu.be/x8pErCJ1bAU?t=34m26s'
+      - 'https://youtu.be/x8pErCJ1bAU?t=34m26s'
   - title: 'The Amazing Tale of the Web S01E03: The Rise of JS'
-    extract: >
-        Le dernier de la trilogie, the Rise of JS couvrira les 10 dernières années.
-        Les beaux jours du web dynamique battent leur plein, et déjà quelques transitions arrivent.
-        Le Wap prend sa retraite, les netbooks et Smartphones arrivent : une transformation doit s'opérer.
-        Un jour, Google annonce son navigateur Chrome, cachant un moteur qui va changer la donne. #DynamicWeb #W3C #HTML5 #WebFrameworks #V8
+    extract: |
+      Le dernier de la trilogie, the Rise of JS couvrira les 10 dernières années.
+      Les beaux jours du web dynamique battent leur plein, et déjà quelques transitions arrivent.
+      Le Wap prend sa retraite, les netbooks et Smartphones arrivent : une transformation doit s'opérer.
+      Un jour, Google annonce son navigateur Chrome, cachant un moteur qui va changer la donne. #DynamicWeb #W3C #HTML5 #WebFrameworks #V8
 
-        Cet épisode 3, c'est comprendre la transition du monde dynamique vers un modèle client-serveur, la fracture engendrée par les nouveaux devices, le mouvement des technologies pour répondre à ces nouveaux usages (Node.js, Play, etc...) et bien sur les frameworks JS
+      Cet épisode 3, c'est comprendre la transition du monde dynamique vers un modèle client-serveur, la fracture engendrée par les nouveaux devices, le mouvement des technologies pour répondre à ces nouveaux usages (Node.js, Play, etc...) et bien sur les frameworks JS
     authors:
       - name: 'Loic Ortola'
         url: 'http://twitter.com/loicortola'
@@ -46,5 +46,5 @@ talks:
     slides: []
     links: []
     videos:
-        - 'https://youtu.be/x8pErCJ1bAU'
+      - 'https://youtu.be/x8pErCJ1bAU'
 ---

--- a/content/meetups/2018-08-30.md
+++ b/content/meetups/2018-08-30.md
@@ -6,10 +6,10 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/251642397/'
 talks:
   - title: 'Comment connecter 1980 et 2018 avec une extension Chrome et Chrome Native Messaging'
-    extract: >
-        Chez Doctolib, nous avons à nous interfacer avec des logiciels allant du site web en SAAS au logiciel natif développé en 1980. Presqu'aucun de ces logiciels n'est prévu pour la communication avec d'autres outils. Nous avons mis en place une architecture multi couches articulée autour d'une extension Chrome : injection d'une API javascript dans les pages de nos partenaires ou lancement d'un binaire avec Chrome Native messaging pour communiquer avec des logiciels installés directement sur le poste de nos clients.
+    extract: |
+      Chez Doctolib, nous avons à nous interfacer avec des logiciels allant du site web en SAAS au logiciel natif développé en 1980. Presqu'aucun de ces logiciels n'est prévu pour la communication avec d'autres outils. Nous avons mis en place une architecture multi couches articulée autour d'une extension Chrome : injection d'une API javascript dans les pages de nos partenaires ou lancement d'un binaire avec Chrome Native messaging pour communiquer avec des logiciels installés directement sur le poste de nos clients.
 
-        Nous présenterons au cours de ce talk la manière de créer une extension Chrome permettant de réaliser ce type d'actions. Nous parlerons ensuite du déploiement de binaires sur les postes clients en utilisant un Node.JS embarqué (PKG), communiquant avec un site web au travers de Chrome Native Messaging.
+      Nous présenterons au cours de ce talk la manière de créer une extension Chrome permettant de réaliser ce type d'actions. Nous parlerons ensuite du déploiement de binaires sur les postes clients en utilisant un Node.JS embarqué (PKG), communiquant avec un site web au travers de Chrome Native Messaging.
     authors:
       - name: 'Matthieu Kern'
         url: 'http://twitter.com/MatthieuKern'
@@ -18,38 +18,38 @@ talks:
         url: 'http://twitter.com/QuentinMenoret'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/QuentinMenoret&amps;embed=image.url'
     slides:
-        - https://fr.slideshare.net/MatthieuKern1/how-to-connect-1980-and-2018
+      - https://fr.slideshare.net/MatthieuKern1/how-to-connect-1980-and-2018
     links: []
     videos:
-        - https://youtu.be/K-zHEcSPwi4?t=11m
+      - https://youtu.be/K-zHEcSPwi4?t=11m
   - title: "Yarn: Hier, Aujourd'hui, et Demain"
-    extract: >
-        Cela fait maintenant deux ans que Yarn fait parti du paysage Javascript, et s'est installé dans les deux principaux gestionnaires de paquets avec npm.
+    extract: |
+      Cela fait maintenant deux ans que Yarn fait parti du paysage Javascript, et s'est installé dans les deux principaux gestionnaires de paquets avec npm.
 
-        Porté par un core maintainer de Yarn, ce talk a pour but de faire une retrospective sur cette période, revenir sur les principales fonctionnalités qui restent son apanage, et offrir un aperçu des avancées à venir.
+      Porté par un core maintainer de Yarn, ce talk a pour but de faire une retrospective sur cette période, revenir sur les principales fonctionnalités qui restent son apanage, et offrir un aperçu des avancées à venir.
     authors:
       - name: Maël Nison
         url: 'https://twitter.com/arcanis'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/arcanis&amps;embed=image.url'
     slides: []
     links:
-        - https://yarnpkg.com
+      - https://yarnpkg.com
     videos:
-        - https://youtu.be/K-zHEcSPwi4?t=38m
+      - https://youtu.be/K-zHEcSPwi4?t=38m
   - title: 'Serveur-client GraphQL via Apollo'
-    extract: >
-        La révolution est en marche, GraphQL devient de plus en plus populaire. Mais c'est quoi ?
-        GraphQL est un manifeste Facebook, qui met en place un language de query permettant de créer des APIs facilement, pouvant communiquer avec n'importe qu'elle source de données.
+    extract: |
+      La révolution est en marche, GraphQL devient de plus en plus populaire. Mais c'est quoi ?
+      GraphQL est un manifeste Facebook, qui met en place un language de query permettant de créer des APIs facilement, pouvant communiquer avec n'importe qu'elle source de données.
 
-        Le talk permet de mettre en place un serveur GraphQL, avec un client React en utilisant la librairie Apollo.
+      Le talk permet de mettre en place un serveur GraphQL, avec un client React en utilisant la librairie Apollo.
     authors:
       - name: 'Jonathan'
         url: 'http://twitter.com/captainjojo42'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/captainjojo42&amps;embed=image.url'
     slides:
-        - https://fr.slideshare.net/jonathanjalouzot/graphql-with-apollojs
+      - https://fr.slideshare.net/jonathanjalouzot/graphql-with-apollojs
     links:
-        - https://github.com/duck-invaders/graphql-apollo
+      - https://github.com/duck-invaders/graphql-apollo
     videos:
-        - https://youtu.be/K-zHEcSPwi4?t=1h14m
+      - https://youtu.be/K-zHEcSPwi4?t=1h14m
 ---

--- a/content/meetups/2018-10-24.md
+++ b/content/meetups/2018-10-24.md
@@ -6,8 +6,8 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/251642404/'
 talks:
   - title: 'Découvrez CQRS et Event Sourcing !'
-    extract: >
-        Chez Everoad, nous avons mis en place une architecture microservice basée sur les patterns CQRS et Event Sourcing. L'objectif de ce talk est de vous présenter ces deux concepts et de vous partager notre retour d'expérience sur une implémentation en full-Node.js.
+    extract: |
+      Chez Everoad, nous avons mis en place une architecture microservice basée sur les patterns CQRS et Event Sourcing. L'objectif de ce talk est de vous présenter ces deux concepts et de vous partager notre retour d'expérience sur une implémentation en full-Node.js.
     authors:
       - name: 'Yoann Gotthilf'
         url:
@@ -15,42 +15,42 @@ talks:
     slides: []
     links: []
     videos:
-        - https://youtu.be/CzToqxwwebc?t=300
+      - https://youtu.be/CzToqxwwebc?t=300
   - title: 'V8 : Master Garbage Collector'
-    extract: >
-        Le moteur V8 c'est un peu la magie de l'execution de javascript, côté client (chrome) et côté serveur (nodejs). Il gère pour vous la gestion de la mémoire grâce à son garbage collector !
-        Pourquoi un garbage collector dans V8 ?
-        Comprendre comment il fonctionne, quand il passe et pourquoi.
-        Comment optimiser son code pour ne pas créer de problème lié à la mémoire.
-        Comment le monitorer et obtenir des informations.
+    extract: |
+      Le moteur V8 c'est un peu la magie de l'execution de javascript, côté client (chrome) et côté serveur (nodejs). Il gère pour vous la gestion de la mémoire grâce à son garbage collector !
+      Pourquoi un garbage collector dans V8 ?
+      Comprendre comment il fonctionne, quand il passe et pourquoi.
+      Comment optimiser son code pour ne pas créer de problème lié à la mémoire.
+      Comment le monitorer et obtenir des informations.
     authors:
       - name: 'Vincent Vallet'
         url: 'http://twitter.com/vince_vallet'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/vince_vallet&amps;embed=image.url'
     slides:
-        - https://docs.google.com/presentation/d/17PXOZXBgdJHqBZlbULHg70_hVFLrNx9T34rB9bLDn2M/edit?usp=sharing
+      - https://docs.google.com/presentation/d/17PXOZXBgdJHqBZlbULHg70_hVFLrNx9T34rB9bLDn2M/edit?usp=sharing
     links: []
     videos:
-        - https://youtu.be/CzToqxwwebc?t=2335
+      - https://youtu.be/CzToqxwwebc?t=2335
   - title: 'Generating 3D models with Node.js'
-    extract: >
-        What's a 3D model? Why would you generate it with JavaScript and Node.js? How do you do that?
-        Let's find out with this talk!
+    extract: |
+      What's a 3D model? Why would you generate it with JavaScript and Node.js? How do you do that?
+      Let's find out with this talk!
     authors:
       - name: 'Maurice Svay'
         url: 'http://twitter.com/mauriz'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/mauriz&amps;embed=image.url'
     slides:
-        - https://docs.google.com/presentation/d/1QLnCls-OUj_iBwi-Y7oi-x2VXT20oAsZcOnJHTJKjjU/edit?usp=sharing
+      - https://docs.google.com/presentation/d/1QLnCls-OUj_iBwi-Y7oi-x2VXT20oAsZcOnJHTJKjjU/edit?usp=sharing
     links: []
     videos:
-        - https://youtu.be/CzToqxwwebc?t=4216
+      - https://youtu.be/CzToqxwwebc?t=4216
   - title: 'Enregistrer un podcast vidéo'
-    extract: >
-        Pour illustrer mon projet topheman/react-fiber-experiments, j'ai récemment produit un podcast vidéo. L'idée de ce talk serait de partager rapidement :
-        • la façon dont j'ai procédé
-        • les outils que j'ai utilisés
-        • les contraintes que je me suis imposées
+    extract: |
+      Pour illustrer mon projet topheman/react-fiber-experiments, j'ai récemment produit un podcast vidéo. L'idée de ce talk serait de partager rapidement :
+      - la façon dont j'ai procédé
+      - les outils que j'ai utilisés
+      - les contraintes que je me suis imposées
     authors:
       - name: 'Christophe Rosset'
         url: 'http://twitter.com/topheman'
@@ -58,5 +58,5 @@ talks:
     slides: []
     links: []
     videos:
-        - https://youtu.be/CzToqxwwebc?t=4900
+      - https://youtu.be/CzToqxwwebc?t=4900
 ---

--- a/content/meetups/2018-11-07.md
+++ b/content/meetups/2018-11-07.md
@@ -6,8 +6,8 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/251642421/'
 talks:
   - title: 'Event Sourcing'
-    extract: >
-        TBD
+    extract: |
+      TBD
     authors:
       - name: 'Hubert Mine'
         url: https://github.com/hubertmine
@@ -15,11 +15,11 @@ talks:
     slides: []
     links: []
     videos:
-        - https://youtu.be/BJrhq0NHNq8
+      - https://youtu.be/BJrhq0NHNq8
   - title: 'JavaScript and TypeScript everywhere'
-    extract: >
-        JS runs in the browser, JS runs on the server, JS even run on physical devices sometimes. What if we told you that we started to run JS in other applications?
-        In this talk we (Jb Aviat, Sqreen CTO and V. de Turckheim) will show you how we use JavaScript (I mean TypeScript) to enhence the behavior of applications written in diverse languages (Ruby, Python, PHP, Java, ...). We will also talk about the issues we met when embedding a JS engine into other apps and what alternatives we looked at (SPOILER ALERT: THERE WILL BE WebAssembly).
+    extract: |
+      JS runs in the browser, JS runs on the server, JS even run on physical devices sometimes. What if we told you that we started to run JS in other applications?
+      In this talk we (Jb Aviat, Sqreen CTO and V. de Turckheim) will show you how we use JavaScript (I mean TypeScript) to enhence the behavior of applications written in diverse languages (Ruby, Python, PHP, Java, ...). We will also talk about the issues we met when embedding a JS engine into other apps and what alternatives we looked at (SPOILER ALERT: THERE WILL BE WebAssembly).
     authors:
       - name: 'Vladimir de Turckheim'
         url: 'http://twitter.com/poledesfetes'
@@ -30,19 +30,19 @@ talks:
     slides: []
     links: []
     videos:
-        - https://youtu.be/BJrhq0NHNq8?t=1810
+      - https://youtu.be/BJrhq0NHNq8?t=1810
   - title: 'Vulcan.js — The fullstack React-GraphQL framework'
-    extract: >
-        Vulcan.JS, a fullstack GraphQL + React framework, lets you ship webapps fast, using the latest technologies. In this talk, we see the origin story of the framework and an overview of its main features
+    extract: |
+      Vulcan.JS, a fullstack GraphQL + React framework, lets you ship webapps fast, using the latest technologies. In this talk, we see the origin story of the framework and an overview of its main features
     authors:
       - name: 'Apollinaire Lecocq'
         url: https://github.com/Apollinaire
-        avatar: 
+        avatar:
     slides:
       - https://apollinaire.github.io/vulcan-parisjs-slides
     links:
       - https://github.com/VulcanJS/Vulcan
       - https://slack.vulcanjs.org
     videos:
-        - https://youtu.be/BJrhq0NHNq8?t=3212
+      - https://youtu.be/BJrhq0NHNq8?t=3212
 ---

--- a/content/meetups/2018-11-28.md
+++ b/content/meetups/2018-11-28.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/251642436/'
 talks:
   - title: 'Industrialisation des tests end-to-end via Selenium/Nightwatch/Browserstack'
-    extract: >
+    extract: |
       Pourquoi faire des tests fonctionnels via Selenium ?
       Mise en place et industrialisation des tests end-to-end (Docker / Nightwatch / Browserstack)
       Problématiques rencontrées lors de tests multi-browsers.
@@ -19,9 +19,9 @@ talks:
       - https://talks.vibioh.fr/indus_e2e/
     links: []
     videos:
-        - https://youtu.be/RGcARlPyw1o?t=325
+      - https://youtu.be/RGcARlPyw1o?t=325
   - title: 'Les animations en React-Native'
-    extract: >
+    extract: |
       Présentation de l'API Animated pour faire des animations dans React-Native. Avec comme exemple : comment refaire un effet parallaxe au scroll bounce.
     authors:
       - name: Freddy Harris
@@ -32,9 +32,9 @@ talks:
     links:
       - https://l9n55z1m0q.codesandbox.io/
     videos:
-        - https://youtu.be/RGcARlPyw1o?t=2390
+      - https://youtu.be/RGcARlPyw1o?t=2390
   - title: 'How-to: Make your application real-time'
-    extract: >
+    extract: |
       If you want to build an online chat room, a multiplayer game, or a collaborative platform in browsers, you need the power of real-time!
       This talk will show you how to build a real-time web application with socket.io and server-send events.
 

--- a/content/meetups/2019-01-30.md
+++ b/content/meetups/2019-01-30.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/257027880/'
 talks:
   - title: 'React JS / GraphQL expliqués aux développeurs Back-End (Symfony, Node.js...)'
-    extract: >
+    extract: |
       Etant développeur Back-End (Symfony / Node.js) et connaissant l'API Rest, il s'agit de vous apporter des éclairages sur la librairie React JS et sur le langage de requêtes GraphQL.
       A travers de l'exposé seront développées toutes les facettes de ces outils.
     authors:
@@ -17,9 +17,9 @@ talks:
       - https://github.com/parisjs/talks/files/2809486/GraphQL._.React.Js.Explique.aux.devs.backend.pdf
     links: []
     videos:
-        - https://youtu.be/heXd9HL9O8s?t=376
+      - https://youtu.be/heXd9HL9O8s?t=376
   - title: 'Integrating AWS Secrets Manager with Kubernetes using Node.js'
-    extract: >
+    extract: |
       During the past six months I have proudly been working on "Kubernetes external secrets".
       The project, initially developed internally at GoDaddy, is now open source under MIT license on the company public Github.
       Kubernetes external secrets is entirely written in Node.js and it integrates external provides such as AWS Secrets Manager with Kubernetes for securely storing secrets.
@@ -37,9 +37,9 @@ talks:
     links:
       - https://github.com/godaddy/kubernetes-external-secrets
     videos:
-        - https://youtu.be/heXd9HL9O8s?t=1929
+      - https://youtu.be/heXd9HL9O8s?t=1929
   - title: 'Code Prettier Code'
-    extract: >
+    extract: |
       L'objectif de ce talk est de montrer comment et pourquoi convaincre une équipe d'ajouter Prettier à ses projets js/ts dans le court terme. J'y démontre la valeur ajoutée de Prettier, et comment l'installer de bout en bout: comment l'ajouter au projet, l'intégrer aux linters existants, organiser la PR qui appliquera Prettier, merger facilement les branches des autres membres de l'équipe, et les meilleurs moyens de faire en sorte d'appliquer Prettier sur tous les changements futurs.
 
       L'objectif est vraiment de montrer à qui serait intéressé par Prettier, que la complexité de son ajout dans un projet, même gros, est assez réduite pour considérer de le faire sans trop attendre, et que sa valeur ajoutée en vaut le prix.

--- a/content/meetups/2019-02-27.md
+++ b/content/meetups/2019-02-27.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/257184550/'
 talks:
   - title: 'Debugging a Non Reproducible Bug with 20k production crashes'
-    extract: >
+    extract: |
       20 000 crashes en production. Un bug impossible à reproduire. Un cauchemar quoi !
       Laissez-moi vous raconter une glorieuse histoire de debugging, pleine de rebondissements et d'apprentissages.
       J'ai aussi publié un article dessus qui a buzzé sur Reddit (~2000 upvotes), j'espère que ça intéressera tout autant le public de Paris.JS !
@@ -21,7 +21,7 @@ talks:
     videos:
       - https://www.youtube.com/watch?v=jT9uyoyBZas&list=PL4dDsXV05YbtY5MGy_uOM0B7ZLiKrFUfY
   - title: 'Front-end architecture in practice'
-    extract: >
+    extract: |
       Le terme d'architecture est désormais plus que pertinent coté front-end.
       Après une courte introduction sur les 3 révolutions du web, nous verrons comment appliquer simplement des notions d'architecture pour mettre en place une roadmap et une guideline sur votre projet.
     authors:
@@ -34,7 +34,7 @@ talks:
     videos:
       - https://www.youtube.com/watch?v=sK8JCZtiNxc&t=0s&list=PL4dDsXV05YbtY5MGy_uOM0B7ZLiKrFUfY
   - title: 'Good practices'
-    extract: >
+    extract: |
       Un passage en revue des "bonnes pratiques", ces règles établies qu'on ne questionne plus trop.
       Separation of concerns, DRY, TDD, REST, type systems, est-ce que toutes ces pratiques sont encore valables?
     authors:

--- a/content/meetups/2019-03-27.md
+++ b/content/meetups/2019-03-27.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/258319504/'
 talks:
   - title: 'Tester n’importe quel code, même le code dont vous n’êtes pas fier!'
-    extract: >
+    extract: |
       Une approche pragmatique au test de code legacy (code dont on pense qu’il n’est pas testable et que personne veut toucher).
       En utilisant des mock simples et des design patterns, en javascript.
 
@@ -36,7 +36,7 @@ talks:
     videos:
       - https://youtu.be/zUeMu73Md9k?t=600
   - title: 'The Challenging Migration from Heroku to Google Kubernetes Engine'
-    extract: >
+    extract: |
       L'été dernier, on a migré une application Node.js distribuée, de Heroku vers Google Kubernetes Engine. Je pensais que ça allait être facile. Hé bien j'avais tort ! sweat_smile
       Je vais vous raconter les ratés les plus épiques auxquels j'ai du faire face pendant cette migration. Et si vous êtes sympas, je vous expliquerai les astuces que j'ai appliquées pour corriger le tir !
     authors:
@@ -50,7 +50,7 @@ talks:
     videos:
       - https://youtu.be/zUeMu73Md9k?t=2494
   - title: 'From Heroku / Github / CircleCI to Kubernetes (helm/vault) / Gitlab CI CD'
-    extract: >
+    extract: |
       Rex sur la migration d'une société de Heroku (app engine GCP like), Github et CircleCI en Saas vers Kubernetes (via Helm et Vault), et gitlab (avec gitlab-ci) pour la CI/CD.
     authors:
       - name: 'Jérémy Wimsingues'

--- a/content/meetups/2019-04-24.md
+++ b/content/meetups/2019-04-24.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/fr-FR/Paris-js/events/260336485/'
 talks:
   - title: 'Modifier votre codebase à l’aide de codemods'
-    extract: >
+    extract: |
       L'idée de changer un composant qui est utilisé dans quatre cent fichiers de votre codebase vous angoisse ? Certains cas sont trop complexes pour des regex (et de toute façon, qui sait écrire une regex ?) Vous n'êtes pas des machines. Ça tombe bien, votre PC l'est ! Lors de cette talk, je vais présenter jscodeshift, un outil en CLI permettant d'écrire des transformations de code en manipulant un AST.
     authors:
       - name: 'Augustin Le Fèvre '
@@ -20,7 +20,7 @@ talks:
     videos:
       - https://www.youtube.com/watch?v=sWN7b4g_HMg
   - title: 'Elm: beginners and production compliant'
-    extract: >
+    extract: |
       Ce talk présente le langage Elm en mettant en valeur sa simplicité de prise en main pour les débutants, la fiabilité des applications écrites en Elm.
       Live coding included !
       Ce talk n'a pas pour vocation à apprendre le langage, mais plutôt montrer son potentiel.
@@ -35,7 +35,7 @@ talks:
     videos:
       - https://www.youtube.com/watch?v=kLumTtZ8awI
   - title: 'Abstract Components'
-    extract: >
+    extract: |
       Capture ideas in a more efficient ways with your abstractions by incorporating a tiered way of thinking. By making sure each level exposes the underlying levels of customisation, and making sure the current level is overridable, you're ensuring your ideas you incorporated in an abstraction continue to exist, even with customisation.
     authors:
       - name: 'Haroen Viaene'

--- a/content/meetups/2019-05-29.md
+++ b/content/meetups/2019-05-29.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/260336623/'
 talks:
   - title: 'React Hooks & React Context'
-    extract: >
+    extract: |
       Ce talk présente le fonctionnement de React Hooks & React Context : quels sont leurs apports et comment en tirer parti dans la mise en place d'un state global, afin de se passer de solutions externes comme Redux.
     authors:
       - name: 'Grégory Bellencontre'
@@ -15,7 +15,7 @@ talks:
     videos:
       - https://youtu.be/ZU1fbYvLB9U
   - title: 'React-Native Getting started'
-    extract: >
+    extract: |
       Présentation de React-Native, par où commencer?
       Qu'est ce qu'Expo?
       Live Coding : Getting started expo app and native app
@@ -29,7 +29,7 @@ talks:
     videos:
       - https://youtu.be/T36WVwiVqhw
   - title: 'Animations : comment atteindre rapidement le standard du marché, et au delà'
-    extract: >
+    extract: |
       Retour d'expérience sur plusieurs mois d'apprentissages sur les animations en React Native. Quelles sont les clés pour proposer une expérience fluide et cohérente ? Comment fait-on cela techniquement de la plus rapide façon ? Nous allons partir d'animations simples et peu visibles, mais qui, quand elles ne sont pas présentes, font taches. Et nous finirons par des animations plus complexes et "wahou" !
     authors:
       - name: 'Louis Lagrange'

--- a/content/meetups/2019-06-26.md
+++ b/content/meetups/2019-06-26.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/260336640/'
 talks:
   - title: 'WebAssembly va tuer JS (ou pas)'
-    extract: >
+    extract: |
       Bon, WebAssembly, c’est le nouveau cool kid du quartier. Combien de fois on a entendu des collègues balancer un “nan mais bientôt avec WebAssembly on aura plus à subir JS”.
       Mais est-ce bien vrai ? WebAssembly (WASM de son petit nom) va-t-il mettre fin à plusieurs décennies de règne sans partage de JS sur les browsers ?
       Mais d’ailleurs, c’est quoi WASM ?
@@ -23,7 +23,7 @@ talks:
     videos:
       - https://youtu.be/-hQw-tbIQ-E
   - title: "Utiliser WebAssembly, dès aujourd'hui"
-    extract: >
+    extract: |
       On commence à entendre parler de plus en plus de WebAssembly. Dans tous les talks, on nous présente des benchmarks, des diagrammes ... on nous explique la théorie ...  
 
       Mais où est le code ? Comment peut-on jouer avec concrètement ?  
@@ -40,8 +40,8 @@ talks:
     links:
       - https://github.com/topheman/rust-wasm-experiments
   - title: 'WebAssembly: post MVP features and goals'
-    extract: >
-      
+    extract: |
+
     authors:
       - name: 'Elia Maino'
         url: 'https://twitter.com/eliamain'

--- a/content/meetups/2019-09-25.md
+++ b/content/meetups/2019-09-25.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/264776672/'
 talks:
   - title: "Comment j'ai fait décoller mon projet perso : une app web et desktop cross-platform"
-    extract: >
+    extract: |
       Je vous propose un REX de mon principal projet perso depuis 3 ans. C'est une application web et desktop compagnon du simulateur de vol X-Plane.
       Comment on fait pour coder une app web + desktop cross-platform ? Comment on la met en prod, comment on la met à jour, comment on la sécurise ?
 
@@ -20,7 +20,7 @@ talks:
     videos:
       - https://youtu.be/a4F-exp90ZQ
   - title: 'CSS, préprocesseurs, BEM, CSS Modules, Styled Components... comment choisir ?'
-    extract: >
+    extract: |
       "L'environnement CSS a bien évolué au fur et à mesure de ces 20 dernières années. Cependant, il semble toujours difficile d'écrire du CSS fonctionnel et maintenable : en 2019, que choisir pour son projet afin d'y arriver ? Avec un processus qui se veut le plus objectif possible, nous établirons une checklist de ce qu'est une bonne stack CSS afin de choisir les technos qui vous conviendront le mieux."
     authors:
       - name: 'Albéric Trancart'
@@ -29,7 +29,7 @@ talks:
     videos:
       - https://youtu.be/3ztP8ujDkhI
   - title: 'La conversion de type en JavaScript'
-    extract: >
+    extract: |
       Est-ce que tout est objet en JavaScript ?
       Vaut-il vraiment mieux utiliser === plutôt que == ? Pourquoi ?
       Pourquoi [] + [] donne une chaîne vide ?

--- a/content/meetups/2019-10-30.md
+++ b/content/meetups/2019-10-30.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/264722007/'
 talks:
   - title: "Tour d'horizon de Yarn 2!"
-    extract: >
+    extract: |
       Introduit il y a bientôt trois ans, Yarn s'est depuis lors taillé une solide place dans l'écosystème JavaScript grâce à sa mise au premier plan des problèmes de stabilité et de consistance. Il est maintenant temps de découvrir ce que Yarn 2 nous réserve, et vous dévoiler les prochaines étapes de notre plan visant à rendre vos applications plus stables, et vos cycles de développement plus abordables.
     authors:
       - name: 'Maël Nison'
@@ -17,7 +17,7 @@ talks:
     videos:
       - https://youtu.be/U8eV3XGInRU
   - title: 'Property based testing : de la théorie à la pratique'
-    extract: >
+    extract: |
       Apparu dans le monde fonctionnel avec QuickCheck, le property based testing est une nouvelle approche pour tester le bon fonctionnement d'une application.
       Il permet de détecter des bugs en quelques lignes sans avoir à spécifier l'ensemble des cas limites et s'avère être un allié puissant aux tests unitaires classiques.
       Nous verrons ensemble ce qu'est le property based testing.
@@ -33,7 +33,7 @@ talks:
     videos:
       - https://youtu.be/lOnb50OpIec
   - title: 'Un voyage de deux ans au coeur d’une application JS fullstack'
-    extract: >
+    extract: |
       En 2017, je commençais mon premier projet en tant que lead tech. A cette époque, je faisais mes premiers pas en react-native et j'étais accompagné de deux développeurs. Notre objectif: construire un POC en 4 semaines pour démontrer que nous pouvions déverrouiller une voiture à l’aide d’une application mobile codée en react-native.
 
       En deux ans, cette équipe a fait beaucoup de chemin. Le POC est maintenant devenu une application complète permettant de visualiser la disponibilité de centaines de voitures dans Paris, elle est devenu le métier principal de notre client et l’équipe est maintenant composé de 10 développeurs. Cependant, cette évolution s'est accompagnée de nombreux défis: Des bugs, de la dette technique, des bugs, des ralentissements de l’équipe, des mauvaises conceptions architecturales faites par votre serviteur et ah oui, des bugs.
@@ -52,7 +52,7 @@ talks:
     videos:
       - https://youtu.be/5Nzuyu0u6T4
   - title: 'How to refactor your API without bugs using GraphQL and static type-checking'
-    extract: >
+    extract: |
       Is this field still used? Can I safely delete it? When refactoring an API, that's a question you can ask yourself. In this talk, I will show how Relay and static typing can help you refactor your GraphQL API quickly and without introducing defects.
     authors:
       - name: 'Bastien Duret'

--- a/content/meetups/2019-11-27.md
+++ b/content/meetups/2019-11-27.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/266104891/'
 talks:
   - title: 'Développer des structures de données en JavaScript'
-    extract: >
+    extract: |
       There is a tenacious misconception nowadays that people working with JavaScript do not need to know much about data structures because developing for the web is still often deemed to be, and this cannot be more false, an easier task than "real" programming.
 
       Web applications have become complex beasts and node.js allows to build programs that used to be other backend languages' turf. JavaScript developers now need to develop, as with any other programming language, custom data structures to solve particular problems when arrays and objects are simply not enough. The intention of this presentation is therefore to compile series of tips, tricks and use cases regarding the implementation of data structures in JavaScript and the challenges it poses. It is indeed tricky to ensure consistent performance in a high-level language with JIT and where engines like v8 apply a lot of optimization magic. One has to be able to evolve around those constraints. Examples will be taken from libraries such as graphology, sigma.js' newest version and finally mnemonist to demonstrate that 1. performant data structures can be designed for JavaScript using the language's capabilities and that 2. everyone can use them to solve problems more efficiently.
@@ -19,7 +19,7 @@ talks:
     videos:
       - https://www.youtube.com/watch?v=2-_HaPjEIdY
   - title: 'Mise à l’échelle d’une application web'
-    extract: >
+    extract: |
       "Il me faut un mois de refacto avant de commencer le dev…”, "C’est bon, je finis au prochain sprint" (dit pareil depuis 3 mois), "C’est du code legacy, ça" (fait au sprint dernier). Je suis sur que vous avez déjà entendu ça quelque part... Dans cette présentation, je décris le niveau de qualité dans notre web app AngularJS qui n'a pas grossi très sereinement. Des événements, des références d'objets javascript, des scopes de composants, des états dans des services angular, etc.
       Comment s'est-on réveillé de ce cauchemard ? Vous verrez comment Redux a stabilisé la gestion de l'état applicatif, React a introduit un meilleur design orienté composant et amélioré la performance et enfin, comment RxJS a découplé le cycle de vie des composants de celui des données !
     authors:
@@ -31,7 +31,7 @@ talks:
     videos:
       - https://www.youtube.com/watch?v=VsKSvogE8pE
   - title: 'Smooth animations that load fast, with Lottie and Webpack'
-    extract: >
+    extract: |
       How to build a Webpack loader to handle Lottie animation files
     authors:
       - name: 'Antoine Jackson'

--- a/content/meetups/2019-12-05.md
+++ b/content/meetups/2019-12-05.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/265143723/'
 talks:
   - title: 'Gatsby - How is it different from other static site generator?'
-    extract: >
+    extract: |
       Gatsby.js is one of the most popular and hype static website generator of the moment. Having built my latest project with it and having a long experience with this kind of technology, I want to answer two questions with this talk:
       - how is it different from other generators?
       - is it the right tool for you?
@@ -15,7 +15,7 @@ talks:
         url: 'https://twitter.com/bobylito'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/bobylito&amps;embed=image.url'
   - title: 'About Svelte'
-    extract: >
+    extract: |
       "Yet another JavaScript component framework ? Seriously ? 
       Actually yes, but Svelte offers a refreshing new approach to web app development. All features of this framework are designed to improve the developer experience and productivity while producing mind blowing results for your users. Let's have a look."
     authors:
@@ -23,7 +23,7 @@ talks:
         url: 'https://twitter.com/kramp'
         avatar: 'https://api.microlink.io/?url=https://twitter.com/kramp&amps;embed=image.url'
   - title: 'The NodeBots band: creating and augmenting music with JS and WebAssembly'
-    extract: >
+    extract: |
       This talk is about the importance of art and play in Node, about the abilities Node has gained in its ten years as a project. There's a musical number and a discussion of MIDI as a way to send data. Let's dive into the ways Node can be used that we don't always think about.
     authors:
       - name: 'Mx. Kassian Wren'

--- a/content/meetups/2020-01-29.md
+++ b/content/meetups/2020-01-29.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/267905446/'
 talks:
   - title: 'Chrome Dev Tools Tips'
-    extract: >
+    extract: |
       Lassé de devoir attendre plus de 10 minutes la fin d'un build qui ne faisait que tester ma codebase, j'ai décidé d'améliorer la CI de mon projet Web. J'ai divisé le temps de CI par 2, et en bonus j'ai automatisé des tâches fastidieuses et répétitives pour mon équipe sans rallonger le build.
       Durant ce talk, je vous présenterai la recette pour une CI intelligente et efficace :
       - les workflows CircleCI pour paralléliser vos tâches
@@ -20,7 +20,7 @@ talks:
     videos:
       - https://www.youtube.com/watch?v=WrJw3Is_-Cs
   - title: 'Faites bien plus que des tests avec votre CI tout en la maintenant sous les 5 minutes'
-    extract: >
+    extract: |
       On connait tous chrome dev tools, depuis des années ça nous permet d'inspecter le DOM et de mesurer les temps de réponses.
       Mais cet outils regorge de fonctionnalités parfois un peu cachées.
       Et si on tentait de les déterrer et d'expliquer pourquoi certaines sont juste incroyables.
@@ -34,7 +34,7 @@ talks:
     slides:
       - https://drive.google.com/file/d/10pTySBun0SvRP8zvM5Ms6D5JDR5mO6CY/view?usp=sharing
   - title: "CodePush: Deploiement d'application de A à Z"
-    extract: >
+    extract: |
       Description et retours d'experience sur CodePush de Microsoft.
       - Mise en place
       - Deploiement d'application et de mise à jour

--- a/content/meetups/2020-02-26.md
+++ b/content/meetups/2020-02-26.md
@@ -6,7 +6,7 @@ sponsors: []
 meetupLink: 'https://www.meetup.com/Paris-js/events/268482228/'
 talks:
   - title: 'Implementing complex design systems in your front-end'
-    extract: >
+    extract: |
       As companies work on features and evolve their product, design systems become increasingly used and front-end engineers find themselves working with atomic components more and more. Our goal is to make our front-end components into our single source of truth, instead of the sketch files, and we'd like to share a few thoughts on how we're going about it.
     authors:
       - name: 'Andrey Soloviev'
@@ -14,7 +14,7 @@ talks:
         avatar: 'https://api.microlink.io/?url=https://twitter.com/MindRave&amps;embed=image.url'
     videos:
   - title: 'Real-world ReasonReact'
-    extract: >
+    extract: |
       Un live coding présentant comment on développe une web app avec ReasonReact. Approche de divers sujets tels que les Future, les types Result, les reducerComponents, les souscriptions et le routing.
     authors:
       - name: Matthias Le Brun
@@ -23,7 +23,7 @@ talks:
     videos:
     slides:
   - title: "Server-side rendering, Twig, Vue, un ménage à 3 qui n'a pas fonctionné "
-    extract: >
+    extract: |
       Il y a 6 mois, j'ai rejoint le projet d'une plate-forme e-commerce: Tarkett, multinationale française spécialisée dans le revêtement de sols.
 
       Initialement développé en Symfony, le site s'est progressivement orienté sur une solution hybride Symfony/Vue.js afin de rendre dynamiques certaines parties du site.
@@ -40,7 +40,7 @@ talks:
     authors:
       - name: 'Cyril'
   - title: 'Au-delà de la pagination : rendre vos tableaux React performants grâce au windowing'
-    extract: >
+    extract: |
       Si vous avez déjà essayé d'afficher un tableau contenant beaucoup d'éléments en React, vous savez probablement que cela peut très vite dégrader les performances de votre site. Nous allons aborder les techniques suivantes pour améliorer les performances :
 
       Une solution simple : la pagination

--- a/styles/Talk.css
+++ b/styles/Talk.css
@@ -20,6 +20,7 @@
 }
 
 .Talk__description {
+  white-space: pre-line;
   line-height: 24px;
   margin: 6px 0;
 }


### PR DESCRIPTION
Fixes #159

Correction: CSS + utiliser "|" dans le frontmatter pour avoir du multiline

### Avant
<img width="967" alt="Screenshot 2021-01-11 at 18 56 28" src="https://user-images.githubusercontent.com/2125859/104220006-27a91f80-543f-11eb-8dae-e7ced3ff4bb1.png">

### Après
<img width="1000" alt="Screenshot 2021-01-11 at 18 56 13" src="https://user-images.githubusercontent.com/2125859/104219996-24159880-543f-11eb-85a8-a47620ed3235.png">
