### PR TITLE
Fix rehydration bug related to nested paragraphs

### DIFF
--- a/components/TalkSubmissionContainer.js
+++ b/components/TalkSubmissionContainer.js
@@ -269,12 +269,10 @@ class TalkSubmissionContainer extends React.Component {
           <h1>
             <FormattedMessage id="SUBMIT_TALK" />
           </h1>
-          <p>
-            <FormattedHTMLMessage
-              id="TALK_EXPLAIN"
-              values={{ link: 'https://github.com/parisjs/talks/issues' }}
-            />
-          </p>
+          <FormattedHTMLMessage
+            id="TALK_EXPLAIN"
+            values={{ link: 'https://github.com/parisjs/talks/issues' }}
+          />
           {this.state.githubToken ? (
             !this.state.talkSubmissionLink ? (
               <TalkSubmissionForm onSubmit={this.handleSubmit} />


### PR DESCRIPTION
Fixes #225 

La rehydration ne semble pas bien se comporter lorsqu'on a des paragraphes imbriqués. Ce qui est le cas des instructions de la page de soumission de sujets.